### PR TITLE
Publishing

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -93,3 +93,7 @@ module ActionSubscriber
 end
 
 require "action_subscriber/railtie" if defined?(Rails)
+
+at_exit do
+  ::ActionSubscriber::RabbitConnection.publisher_disconnect!
+end

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -20,6 +20,7 @@ require "action_subscriber/subscribable"
 require "action_subscriber/bunny/subscriber"
 require "action_subscriber/march_hare/subscriber"
 require "action_subscriber/babou"
+require "action_subscriber/publisher"
 require "action_subscriber/threadpool"
 require "action_subscriber/base"
 

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -11,11 +11,12 @@ module ActionSubscriber
                   :pop_interval,
                   :port,
                   :prefetch,
+                  :publisher_confirms,
                   :threadpool_size,
                   :timeout,
                   :times_to_pop
 
-    DEFAULTS = { 
+    DEFAULTS = {
       :allow_low_priority_methods => false,
       :default_exchange => 'events',
       :heartbeat => 5,
@@ -25,6 +26,7 @@ module ActionSubscriber
       :pop_interval => 100, # in milliseconds
       :port => 5672,
       :prefetch => 200,
+      :publisher_confirms => false,
       :threadpool_size => 8,
       :timeout => 1,
       :times_to_pop => 8
@@ -51,7 +53,6 @@ module ActionSubscriber
     ##
     # Instance Methods
     #
-
     def initialize
       self.decoder = {
         'application/json' => lambda { |payload| JSON.parse(payload) },

--- a/lib/action_subscriber/publisher.rb
+++ b/lib/action_subscriber/publisher.rb
@@ -1,0 +1,44 @@
+module ActionSubscriber
+  module Publisher
+    # Publish a message to RabbitMQ
+    #
+    # @param [String] route The routing key to use for this message.
+    # @param [String] payload The message you are sending. Should already be encoded as a string.
+    # @param [String] exchange The exchange you want to publish to.
+    # @param [Hash] options hash to set message parameters (e.g. headers)
+    def self.publish(route, payload, exchange_name, options = {})
+      with_exchange(exchange_name) do |exchange|
+        exchange.publish(payload, publishing_options(route, options))
+      end
+    end
+
+    def self.with_exchange(exchange_name)
+      connection = RabbitConnection.publisher_connection
+      channel = connection.create_channel
+      begin
+        channel.confirm_select if ActionSubscriber.configuration.publisher_confirms
+        exchange = channel.topic(exchange_name)
+        yield(exchange)
+        channel.wait_for_confirms if ActionSubscriber.configuration.publisher_confirms
+      ensure
+        channel.close rescue nil
+      end
+    end
+
+    def self.publishing_options(route, options = {})
+      options[:mandatory] = false unless options.key(:mandatory)
+      options[:persistent] = false unless options.key(:persistent)
+      options[:routing_key] = route
+
+      if ::RUBY_PLATFORM == "java"
+        java_options = {}
+        java_options[:mandatory]   = options.delete(:mandatory)
+        java_options[:routing_key] = options.delete(:routing_key)
+        java_options[:properties]  = options
+        java_options
+      else
+        options
+      end
+    end
+  end
+end

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -21,10 +21,8 @@ describe "A Basic Subscriber", :integration => true do
 
   context "ActionSubscriber.auto_pop!" do
     it "routes messages to the right place" do
-      channel = connection.create_channel
-      exchange = channel.topic("events")
-      exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
-      exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
+      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
+      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
 
       verify_expectation_within(2.0) do
         ::ActionSubscriber.auto_pop!

--- a/spec/lib/action_subscriber/publisher_spec.rb
+++ b/spec/lib/action_subscriber/publisher_spec.rb
@@ -1,0 +1,35 @@
+describe ::ActionSubscriber::Publisher do
+  let(:exchange) { double("Rabbit Exchange") }
+  let(:exchange_name) { "events" }
+  let(:payload) { "Yo Dawg" }
+  let(:route) { "bob.users.created" }
+
+  before { allow(described_class).to receive(:with_exchange).with(exchange_name).and_yield(exchange) }
+
+  describe '.publish' do
+
+    if ::RUBY_PLATFORM == "java"
+      it "publishes to the exchange with default options for march_hare" do
+        expect(exchange).to receive(:publish) do |published_payload, published_options|
+          expect(published_payload).to eq(payload)
+          expect(published_options[:routing_key]).to eq(route)
+          expect(published_options[:mandatory]).to eq(false)
+          expect(published_options[:properties][:persistent]).to eq(false)
+        end
+
+        described_class.publish(route, payload, exchange_name)
+      end
+    else
+      it "publishes to the exchange with default options for bunny" do
+        expect(exchange).to receive(:publish) do |published_payload, published_options|
+          expect(published_payload).to eq(payload)
+          expect(published_options[:routing_key]).to eq(route)
+          expect(published_options[:persistent]).to eq(false)
+          expect(published_options[:mandatory]).to eq(false)
+        end
+
+        described_class.publish(route, payload, exchange_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an implementation of my idea from #22 

The idea here is that we support a very basic form of publishing. ActionSubscriber handles the connection and a few compatibility issues between bunny and march_hare, but we aren't tackling encoding, content-types, etc.

For MX this would allow us to keep Buttress::Syncable and our protobuf encoding stuff intact, but remove all of our `if jRuby` conditionals. Buttress would no longer need to release jruby versions of that gem.

We could then create an `ActionPublisher` or perhaps `ActiveSyncable` gem that provides similar functionality in a more generic way so we can open source it.

/cc @brettallred @liveh2o @abrandoned @localshred 