### PR TITLE
add flag for allow-low-priority-methods

### DIFF
--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.add_dependency 'lifeguard'
   spec.add_dependency 'middleware'
+  spec.add_dependency 'thor'
 
   spec.add_development_dependency "activerecord", ">= 3.2"
   spec.add_development_dependency "bundler", ">= 1.6"

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require 'active_support'
-require 'active_support/core_ext'
 require 'thor'
+require 'action_subscriber'
 
 module ActionSubscriber
   class CLI < ::Thor
+    class_option :allow_low_priority_methods, :type => :boolean, :desc => "subscribe to low priority queues in addition to the normal queues", :default => false
     class_option :app, :default => "./config/environment.rb"
     class_option :mode
     class_option :host


### PR DESCRIPTION
After deploying this into our production servers I realized that we needed an easy way to turn on/off the low priority methods/queues.

This just adds a command line option that gets passed into the configuration object to turn this feature on or off.

/cc @brettallred @localshred @liveh2o @abrandoned 