### PR TITLE
let the app load action_subscriber so we can check `if defined?(Rails)`

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
+require 'active_support'
+require 'active_support/core_ext'
 require 'thor'
-require 'action_subscriber'
 
 module ActionSubscriber
   class CLI < ::Thor


### PR DESCRIPTION
In the last PR (#27) I broke the way we load the `lib/action_subscriber/railtie.rb` file because we try to require it before we have required the `app` file (`config/enviornment.rb`).

This just reverts to the old behavior which lets the app decide what order to load things.

@ztoolson @ryanbjones @liveh2o @abrandoned 