### PR TITLE
we want to copy the options passed in while determining publishing op…

### DIFF
--- a/lib/action_subscriber/publisher.rb
+++ b/lib/action_subscriber/publisher.rb
@@ -25,10 +25,12 @@ module ActionSubscriber
       end
     end
 
-    def self.publishing_options(route, options = {})
-      options[:mandatory] = false unless options.key(:mandatory)
-      options[:persistent] = false unless options.key(:persistent)
-      options[:routing_key] = route
+    def self.publishing_options(route, in_options = {})
+      options = {
+        :mandatory => false,
+        :persistent => false,
+        :routing_key => route,
+      }.merge(in_options)
 
       if ::RUBY_PLATFORM == "java"
         java_options = {}


### PR DESCRIPTION
…tions

allows `in_options` to be frozen and not get a mutation when passed through

@mmmries 