### PR TITLE
Graceful shutdown

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -41,14 +41,9 @@ module ActionSubscriber
   end
 
   if ::RUBY_PLATFORM == "java"
-    require "java"
-    class ShutdownHook
-      include java.lang.Runnable
-      def run
-        ::ActionSubscriber::Babou.stop_server!
-      end
+    at_exit do
+      ::ActionSubscriber::Babou.stop_server!
     end
-    java.lang.Runtime.getRuntime.addShutdownHook(java.lang.Thread.new(ShutdownHook.new))
   else
     [:INT, :QUIT, :TERM].each do |signal|
       trap(signal) do

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -47,12 +47,10 @@ module ActionSubscriber
 
       # Going to wait until the thread pool drains or we wait for 1000 seconds
       # Only waiting for shut down in pop mode
-      if ::ActionSubscriber::Babou.pop?
-        while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
-          Thread.pass
-          wait_loops = wait_loops + 1
-          sleep 1
-        end
+      while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
+        Thread.pass
+        wait_loops = wait_loops + 1
+        sleep 1
       end
 
       exit 0

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -11,6 +11,7 @@ module ActionSubscriber
     class_option :mode
     class_option :host
     class_option :hosts
+    class_option :prefetch, :type => :numeric, :desc => "how many messages to hold in the local queue in subscribe mode"
     class_option :pop_interval, :type => :numeric, :desc => "how long to wait between asking for messages (in milliseconds)"
     class_option :port, :type => :numeric
     class_option :threadpool_size, :type => :numeric
@@ -39,21 +40,21 @@ module ActionSubscriber
     end
   end
 
-  [:INT, :QUIT, :TERM].each do |signal|
-    trap(signal) do
-      puts "Stopping server..."
-      wait_loops = 0
-      ::ActionSubscriber::Babou.stop_server!
-
-      # Going to wait until the thread pool drains or we wait for 1000 seconds
-      # Only waiting for shut down in pop mode
-      while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
-        Thread.pass
-        wait_loops = wait_loops + 1
-        sleep 1
+  if ::RUBY_PLATFORM == "java"
+    require "java"
+    class ShutdownHook
+      include java.lang.Runnable
+      def run
+        ::ActionSubscriber::Babou.stop_server!
       end
-
-      exit 0
+    end
+    java.lang.Runtime.getRuntime.addShutdownHook(java.lang.Thread.new(ShutdownHook.new))
+  else
+    [:INT, :QUIT, :TERM].each do |signal|
+      trap(signal) do
+        ::ActionSubscriber::Babou.stop_server!
+        exit 0
+      end
     end
   end
 end

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -94,7 +94,6 @@ module ActionSubscriber
       ::ActionSubscriber::Babou.stop_receving_messages!
 
       # Going to wait until the thread pool drains or we wait for 1000 seconds
-      # Only waiting for shut down in pop mode
       while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
         puts "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
         Thread.pass

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -99,9 +99,7 @@ module ActionSubscriber
         puts "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
         Thread.pass
         wait_loops = wait_loops + 1
-        puts "incremented wait_loops"
         sleep 1
-        puts "done sleeping, let's check again"
       end
 
       puts "threadpool empty. Shutting down"

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -18,7 +18,7 @@ module ActionSubscriber
       # default check interval to 100ms
       while true
         ::ActionSubscriber.auto_pop! unless shutting_down?
-        sleep sleep_time 
+        sleep sleep_time
         break if shutting_down?
       end
     end
@@ -76,6 +76,11 @@ module ActionSubscriber
 
     def self.stop_server!
       @shutting_down = true
+      ::Thread.new do
+        ::ActionSubscriber::Base.inherited_classes.each do |subscriber|
+          subscriber.cancel_consumers!
+        end
+      end.join
     end
 
     def self.shutting_down?


### PR DESCRIPTION
This addresses #24 

This is an attempt to fix the problem where currently when you send a `SIGTERM` to your action_subscriber process in `subscribe` mode, it will close the connection immediately. This means that any events sitting in the local queue that were fetched without acknowledgement or any events that have been acknowledged and are sitting in the threadpool will be lost.

The fix is to keep class instance variables of all the consumers that we started up when the process started. Then when we catch a SIGTERM message we tell all those consumers to `cancel`. This informs RabbitMQ to cancel our subscription for new messages, but leaves the connection open so we can continue acknowledging and working on the messages we already received.

Then we go into a wait loop which checks the threadpool and waits for it to empty out (or gives up after 1000 seconds)
> Note: 1000 seconds was the current timeout for our graceful shutdown in `pop` mode, but it seems very excessive to me. I think we should reduce this to a configurable timeout which defaults to 60 seconds

jRuby output look like this during shutdown:
```
^CStopping server...
cancelling consumers for BaconSubscriber
finished cancelling consumers
waiting for threadpool to empty (2)
waiting for threadpool to empty (1)
threadpool empty. Shutting down
```

MRI output looks like this during shutdown:
```
^CStopping server...
cancelling consumers for BaconSubscriber
finished cancelling consumers
waiting for threadpool to empty (2)
waiting for threadpool to empty (2)
threadpool empty. Shutting down
```

/cc @film42 @quixoten @abrandoned @brettallred 