### PR TITLE
Warn when invalid configuration.mode specified

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -35,6 +35,8 @@ module ActionSubscriber
         ::ActionSubscriber::Babou.auto_pop!
       when /subscribe/i then
         ::ActionSubscriber::Babou.start_subscribers
+      else
+        puts "ActionSubscriber.configuration.mode must be 'pop' or 'subscribe'.  Currently set to '#{::ActionSubscriber.configuration.mode}'"
       end
     end
   end

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -36,7 +36,7 @@ module ActionSubscriber
       when /subscribe/i then
         ::ActionSubscriber::Babou.start_subscribers
       else
-        puts "ActionSubscriber.configuration.mode must be 'pop' or 'subscribe'.  Currently set to '#{::ActionSubscriber.configuration.mode}'"
+        fail "ActionSubscriber.configuration.mode must be 'pop' or 'subscribe'.  Currently set to '#{::ActionSubscriber.configuration.mode}'"
       end
     end
   end


### PR DESCRIPTION
Currently, if the ::ActionSubscriber.configuration.mode is invalid, the
application simply fails quietly.

This change will print an error to the console, and hint at what needs
to be changed.

@mmmries @brianstien 