### PR TITLE
Routes

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -77,7 +77,7 @@ module ActionSubscriber
   end
 
   def self.stop_subscribers!
-    route_set.cancel_consumers
+    route_set.cancel_consumers!
   end
 
   ##

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -80,6 +80,10 @@ module ActionSubscriber
     print_subscriptions
   end
 
+  def self.stop_subscribers!
+    @route_set.cancel_consumers! if @route_set
+  end
+
   ##
   # Class aliases
   #

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -37,14 +37,14 @@ module ActionSubscriber
   #
   def self.auto_pop!
     return if ::ActionSubscriber::Threadpool.busy?
-    @route_set.auto_pop!
+    route_set.auto_pop!
   end
 
   # Loop over all subscribers and register each as
   # a subscriber.
   #
   def self.auto_subscribe!
-    @route_set.auto_subscribe!
+    route_set.auto_subscribe!
   end
 
   def self.configuration
@@ -60,11 +60,7 @@ module ActionSubscriber
   end
 
   def self.setup_queues!
-    @route_set ||= begin
-      route_set = RouteSet.new(routes)
-      route_set.setup_queues!
-      route_set
-    end
+    route_set.setup_queues!
   end
 
   def self.start_queues
@@ -81,7 +77,7 @@ module ActionSubscriber
   end
 
   def self.stop_subscribers!
-    @route_set.cancel_consumers! if @route_set
+    route_set.cancel_consumers
   end
 
   ##
@@ -99,6 +95,11 @@ module ActionSubscriber
   ##
   # Private Implementation
   #
+  def self.route_set
+    @route_set ||= RouteSet.new(routes)
+  end
+  private_class_method :route_set
+
   def self.routes
     ::ActionSubscriber::Base.inherited_classes.flat_map do |klass|
       klass.routes

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -81,10 +81,8 @@ module ActionSubscriber
     def self.stop_receving_messages!
       @shutting_down = true
       ::Thread.new do
-        ::ActionSubscriber::Base.inherited_classes.each do |subscriber|
-          subscriber.cancel_consumers!
-          puts "finished cancelling consumers"
-        end
+        ::ActionSubscriber.stop_subscribers!
+        puts "stopped all subscribers"
       end.join
     end
 

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -3,11 +3,6 @@ module ActionSubscriber
     extend ::ActionSubscriber::DefaultRouting
     extend ::ActionSubscriber::DSL
     extend ::ActionSubscriber::Subscribable
-    if ::RUBY_PLATFORM == "java"
-      extend ::ActionSubscriber::MarchHare::Subscriber
-    else
-      extend ::ActionSubscriber::Bunny::Subscriber
-    end
 
     ##
     # Private Attributes

--- a/lib/action_subscriber/default_routing.rb
+++ b/lib/action_subscriber/default_routing.rb
@@ -1,25 +1,21 @@
 module ActionSubscriber
   module DefaultRouting
-    def queues
-      @_queues ||= []
-    end
-
-    def setup_queue!(method_name, exchange_name)
-      queue_name = queue_name_for_method(method_name)
-      routing_key_name = routing_key_name_for_method(method_name)
-
-      channel = connection.create_channel
-      exchange = channel.topic(exchange_name)
-      queue = channel.queue(queue_name)
-      queue.bind(exchange, :routing_key => routing_key_name)
-      return queue
-    end
-
-    def setup_queues!
-      exchange_names.each do |exchange_name|
-        subscribable_methods.each do |method_name|
-          queues << setup_queue!(method_name, exchange_name)
+    def routes
+      @routes ||= begin
+        routes = []
+        exchange_names.each do |exchange_name|
+          subscribable_methods.each do |method_name|
+            routes << ActionSubscriber::Route.new({
+              acknowledgements: acknowledge_messages?,
+              action: method_name,
+              exchange: exchange_name,
+              routing_key: routing_key_name_for_method(method_name),
+              subscriber: self,
+              queue: queue_name_for_method(method_name),
+            })
+          end
         end
+        routes
       end
     end
   end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -59,10 +59,6 @@ module ActionSubscriber
       @_queue_names ||= {}
     end
 
-    def queue_subscription_options
-      @_queue_subscription_options ||= { :manual_ack => acknowledge_messages? }
-    end
-
     def remote_application_name(name = nil)
       @_remote_application_name = name if name
       @_remote_application_name

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -1,0 +1,27 @@
+module ActionSubscriber
+  class Route
+    attr_reader :acknowledgements,
+                :action,
+                :exchange,
+                :routing_key,
+                :subscriber,
+                :queue
+
+    def initialize(attributes)
+      @acknowledgements = attributes.fetch(:acknowledgements)
+      @action = attributes.fetch(:action)
+      @exchange = attributes.fetch(:exchange)
+      @routing_key = attributes.fetch(:routing_key)
+      @subscriber = attributes.fetch(:subscriber)
+      @queue = attributes.fetch(:queue)
+    end
+
+    def acknowledgements?
+      @acknowledgements
+    end
+
+    def queue_subscription_options
+      { :manual_ack => acknowledgements? }
+    end
+  end
+end

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -1,0 +1,35 @@
+module ActionSubscriber
+  class RouteSet
+    if ::RUBY_PLATFORM == "java"
+      include ::ActionSubscriber::MarchHare::Subscriber
+    else
+      include ::ActionSubscriber::Bunny::Subscriber
+    end
+
+    attr_reader :routes
+
+    def initialize(routes)
+      @routes = routes
+    end
+
+    def setup_queues!
+      routes.each do |route|
+        queues[route] = setup_queue(route)
+      end
+    end
+
+  private
+
+    def queues
+      @queues ||= {}
+    end
+
+    def setup_queue(route)
+      channel = ::ActionSubscriber::RabbitConnection.subscriber_connection.create_channel
+      exchange = channel.topic(route.exchange)
+      queue = channel.queue(route.queue)
+      queue.bind(exchange, :routing_key => route.routing_key)
+      queue
+    end
+  end
+end

--- a/spec/lib/action_subscriber/dsl_spec.rb
+++ b/spec/lib/action_subscriber/dsl_spec.rb
@@ -9,10 +9,6 @@ describe ::ActionSubscriber::DSL do
       it "acknowledges messages" do
         expect(subscriber.acknowledge_messages?).to eq(true)
       end
-
-      it "returns expected queue subscription options" do
-        expect(subscriber.queue_subscription_options).to eq( :manual_ack => true )
-      end
     end
 
     context "when at_most_once! is set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,7 @@ RSpec.configure do |config|
   end
   config.after(:each, :integration => true) do
     ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
-    ::ActionSubscriber::Base.inherited_classes.each do |klass|
-      klass.instance_variable_set("@_queues", nil)
-    end
+    ::ActionSubscriber.instance_variable_set("@route_set", nil)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
     ::ActionSubscriber.setup_queues!
   end
   config.after(:each, :integration => true) do
+    ::ActionSubscriber.stop_subscribers!
     ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
     ::ActionSubscriber.instance_variable_set("@route_set", nil)
   end


### PR DESCRIPTION
We have plans to make it possible to have per-action acknowledgements and per-action exchange settings. This PR is a prelude to those features.

> Make the change easy...then make the easy change.
~Kent Beck [source](https://twitter.com/kentbeck/status/250733358307500032)

This PR introduces a `RouteSet` object which holds a bunch of `Route` objects and can then setup queues and start subscribing to those routes. This shrinks the public interface of `ActiveRecord::Base` and shifts some of the responsibility to a new object.

In future PR's we will introduce a new way to "draw routes" and make `DefaultRouting` optional.

/cc @quixoten @localshred @abrandoned @brianstien 

_PS: I'm sorry for the size of this PR. I tried to find a smaller cut at this that made any significant progress and this was the smallest chunk I could find._