### PR TITLE
Explicit routes

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -77,7 +77,7 @@ module ActionSubscriber
   end
 
   def self.stop_subscribers!
-    route_set.cancel_consumers
+    route_set.cancel_consumers!
   end
 
   ##

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -62,7 +62,16 @@ module ActionSubscriber
   end
 
   def self.print_subscriptions
-    ::ActionSubscriber::Base.print_subscriptions
+    puts configuration.inspect
+    route_set.routes.group_by(&:subscriber).each do |subscriber, routes|
+      puts subscriber.name
+      routes.each do |route|
+        puts "  -- method: #{route.action}"
+        puts "    --    exchange: #{route.exchange}"
+        puts "    --       queue: #{route.queue}"
+        puts "    -- routing_key: #{route.routing_key}"
+      end
+    end
   end
 
   def self.setup_queues!

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -80,6 +80,10 @@ module ActionSubscriber
     print_subscriptions
   end
 
+  def self.stop_subscribers!
+    @route_set.cancel_consumers! if @route_set
+  end
+
   ##
   # Class aliases
   #

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -24,6 +24,7 @@ require "action_subscriber/babou"
 require "action_subscriber/publisher"
 require "action_subscriber/route"
 require "action_subscriber/route_set"
+require "action_subscriber/router"
 require "action_subscriber/threadpool"
 require "action_subscriber/base"
 
@@ -53,6 +54,11 @@ module ActionSubscriber
 
   def self.configure
     yield(configuration) if block_given?
+  end
+
+  def self.draw_routes(&block)
+    routes = Router.draw_routes(&block)
+    @route_set = RouteSet.new(routes)
   end
 
   def self.print_subscriptions
@@ -96,16 +102,19 @@ module ActionSubscriber
   # Private Implementation
   #
   def self.route_set
-    @route_set ||= RouteSet.new(routes)
+    @route_set ||= begin
+      puts "DEPRECATION WARNING: We are inferring your routes by looking at your subscribers. This behavior is deprecated and will be removed in version 2.0. Please see the routing guide at https://github.com/mxenabled/action_subscriber/blob/master/routing.md"
+      RouteSet.new(self.send(:default_routes))
+    end
   end
   private_class_method :route_set
 
-  def self.routes
+  def self.default_routes
     ::ActionSubscriber::Base.inherited_classes.flat_map do |klass|
       klass.routes
     end
   end
-  private_class_method :routes
+  private_class_method :default_routes
 
 end
 

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -37,14 +37,14 @@ module ActionSubscriber
   #
   def self.auto_pop!
     return if ::ActionSubscriber::Threadpool.busy?
-    @route_set.auto_pop!
+    route_set.auto_pop!
   end
 
   # Loop over all subscribers and register each as
   # a subscriber.
   #
   def self.auto_subscribe!
-    @route_set.auto_subscribe!
+    route_set.auto_subscribe!
   end
 
   def self.configuration
@@ -60,11 +60,7 @@ module ActionSubscriber
   end
 
   def self.setup_queues!
-    @route_set ||= begin
-      route_set = RouteSet.new(routes)
-      route_set.setup_queues!
-      route_set
-    end
+    route_set.setup_queues!
   end
 
   def self.start_queues
@@ -81,7 +77,7 @@ module ActionSubscriber
   end
 
   def self.stop_subscribers!
-    @route_set.cancel_consumers! if @route_set
+    route_set.cancel_consumers
   end
 
   ##
@@ -99,6 +95,11 @@ module ActionSubscriber
   ##
   # Private Implementation
   #
+  def self.route_set
+    @route_set ||= RouteSet.new(routes)
+  end
+  private_class_method :route_set
+
   def self.routes
     ::ActionSubscriber::Base.inherited_classes.flat_map do |klass|
       klass.routes

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -81,10 +81,8 @@ module ActionSubscriber
     def self.stop_receving_messages!
       @shutting_down = true
       ::Thread.new do
-        ::ActionSubscriber::Base.inherited_classes.each do |subscriber|
-          subscriber.cancel_consumers!
-          puts "finished cancelling consumers"
-        end
+        ::ActionSubscriber.stop_subscribers!
+        puts "stopped all subscribers"
       end.join
     end
 

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -44,17 +44,6 @@ module ActionSubscriber
       @_inherited_classes ||= []
     end
 
-    def self.print_subscriptions
-      puts ::ActionSubscriber.configuration.inspect
-      puts ""
-
-      inherited_classes.each do |klass|
-        puts klass.inspect
-      end
-
-      nil
-    end
-
     ##
     # Class Aliases
     #

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -3,11 +3,6 @@ module ActionSubscriber
     extend ::ActionSubscriber::DefaultRouting
     extend ::ActionSubscriber::DSL
     extend ::ActionSubscriber::Subscribable
-    if ::RUBY_PLATFORM == "java"
-      extend ::ActionSubscriber::MarchHare::Subscriber
-    else
-      extend ::ActionSubscriber::Bunny::Subscriber
-    end
 
     ##
     # Private Attributes

--- a/lib/action_subscriber/default_routing.rb
+++ b/lib/action_subscriber/default_routing.rb
@@ -1,25 +1,21 @@
 module ActionSubscriber
   module DefaultRouting
-    def queues
-      @_queues ||= []
-    end
-
-    def setup_queue!(method_name, exchange_name)
-      queue_name = queue_name_for_method(method_name)
-      routing_key_name = routing_key_name_for_method(method_name)
-
-      channel = connection.create_channel
-      exchange = channel.topic(exchange_name)
-      queue = channel.queue(queue_name)
-      queue.bind(exchange, :routing_key => routing_key_name)
-      return queue
-    end
-
-    def setup_queues!
-      exchange_names.each do |exchange_name|
-        subscribable_methods.each do |method_name|
-          queues << setup_queue!(method_name, exchange_name)
+    def routes
+      @routes ||= begin
+        routes = []
+        exchange_names.each do |exchange_name|
+          subscribable_methods.each do |method_name|
+            routes << ActionSubscriber::Route.new({
+              acknowledgements: acknowledge_messages?,
+              action: method_name,
+              exchange: exchange_name,
+              routing_key: routing_key_name_for_method(method_name),
+              subscriber: self,
+              queue: queue_name_for_method(method_name),
+            })
+          end
         end
+        routes
       end
     end
   end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -59,10 +59,6 @@ module ActionSubscriber
       @_queue_names ||= {}
     end
 
-    def queue_subscription_options
-      @_queue_subscription_options ||= { :manual_ack => acknowledge_messages? }
-    end
-
     def remote_application_name(name = nil)
       @_remote_application_name = name if name
       @_remote_application_name

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -1,0 +1,27 @@
+module ActionSubscriber
+  class Route
+    attr_reader :acknowledgements,
+                :action,
+                :exchange,
+                :routing_key,
+                :subscriber,
+                :queue
+
+    def initialize(attributes)
+      @acknowledgements = attributes.fetch(:acknowledgements)
+      @action = attributes.fetch(:action)
+      @exchange = attributes.fetch(:exchange)
+      @routing_key = attributes.fetch(:routing_key)
+      @subscriber = attributes.fetch(:subscriber)
+      @queue = attributes.fetch(:queue)
+    end
+
+    def acknowledgements?
+      @acknowledgements
+    end
+
+    def queue_subscription_options
+      { :manual_ack => acknowledgements? }
+    end
+  end
+end

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -10,7 +10,7 @@ module ActionSubscriber
     def initialize(attributes)
       @acknowledgements = attributes.fetch(:acknowledgements)
       @action = attributes.fetch(:action)
-      @exchange = attributes.fetch(:exchange)
+      @exchange = attributes.fetch(:exchange).to_s
       @routing_key = attributes.fetch(:routing_key)
       @subscriber = attributes.fetch(:subscriber)
       @queue = attributes.fetch(:queue)

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -1,0 +1,35 @@
+module ActionSubscriber
+  class RouteSet
+    if ::RUBY_PLATFORM == "java"
+      include ::ActionSubscriber::MarchHare::Subscriber
+    else
+      include ::ActionSubscriber::Bunny::Subscriber
+    end
+
+    attr_reader :routes
+
+    def initialize(routes)
+      @routes = routes
+    end
+
+    def setup_queues!
+      routes.each do |route|
+        queues[route] = setup_queue(route)
+      end
+    end
+
+  private
+
+    def queues
+      @queues ||= {}
+    end
+
+    def setup_queue(route)
+      channel = ::ActionSubscriber::RabbitConnection.subscriber_connection.create_channel
+      exchange = channel.topic(route.exchange)
+      queue = channel.queue(route.queue)
+      queue.bind(exchange, :routing_key => route.routing_key)
+      queue
+    end
+  end
+end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -1,0 +1,60 @@
+module ActionSubscriber
+  class Router
+    def self.draw_routes(&block)
+      router = self.new
+      router.instance_eval(&block)
+      router.routes
+    end
+
+    DEFAULT_SETTINGS = {
+      :acknowledgements => false,
+      :exchange => "events",
+    }.freeze
+
+    def default_routing_key_for(route_settings)
+      [
+        route_settings[:publisher],
+        resource_name(route_settings),
+        route_settings[:action].to_s,
+      ].compact.join(".")
+    end
+
+    def default_queue_for(route_settings)
+      [
+        local_application_name,
+        route_settings[:publisher],
+        resource_name(route_settings),
+        route_settings[:action].to_s,
+      ].compact.join(".")
+    end
+
+    def resource_name(route_settings)
+      route_settings[:subscriber].name.underscore.gsub(/_subscriber/, "").to_s
+    end
+
+    def route(subscriber, action, options = {})
+      route_settings = DEFAULT_SETTINGS.merge(options).merge(:subscriber => subscriber, :action => action)
+      route_settings[:routing_key] ||= default_routing_key_for(route_settings)
+      route_settings[:queue] ||= default_queue_for(route_settings)
+      routes << Route.new(route_settings)
+    end
+
+    def routes
+      @routes ||= []
+    end
+
+    def local_application_name
+      @_local_application_name ||= begin
+        local_application_name = case
+                                 when ENV['APP_NAME'] then
+                                   ENV['APP_NAME'].to_s.dup
+                                 when defined?(::Rails) then
+                                   ::Rails.application.class.parent_name.dup
+                                 else
+                                   raise "Define an application name (ENV['APP_NAME'])"
+                                 end
+        local_application_name.downcase
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -28,6 +28,12 @@ module ActionSubscriber
       ].compact.join(".")
     end
 
+    def default_routes_for(subscriber)
+      subscriber.routes.each do |route|
+        routes << route
+      end
+    end
+
     def resource_name(route_settings)
       route_settings[:subscriber].name.underscore.gsub(/_subscriber/, "").to_s
     end

--- a/lib/action_subscriber/subscribable.rb
+++ b/lib/action_subscriber/subscribable.rb
@@ -46,20 +46,6 @@ module ActionSubscriber
       @_local_application_name
     end
 
-    def inspect
-      inspection_string = "#{self.name}\n"
-      exchange_names.each do |exchange_name|
-        inspection_string << "  -- exchange: #{exchange_name}\n"
-        subscribable_methods.each do |method|
-          inspection_string << "    -- method: #{method}\n"
-          inspection_string << "      -- queue:       #{queue_names[method]}\n"
-          inspection_string << "      -- routing_key: #{routing_key_names[method]}\n"
-          inspection_string << "\n"
-        end
-      end
-      return inspection_string
-    end
-
     # Build the `queue` for a given method.
     #
     # If the queue name is not set, the queue name is

--- a/routing.md
+++ b/routing.md
@@ -1,0 +1,46 @@
+# Routing In ActionSubscriber
+
+ActionSubscriber used to automatically discover all your subscribers and infer all their routes based on a default set of rules<sup>[1](#footnotes)</sup>. As of ActionSubscriber `1.5.0` this behavior is deprecated in favor of having the application draw its routes explicitly.
+
+## The Simple Upgrade Path
+
+The simplest way to draw your routes is to create a `config/initializers/action_subscriber.rb` file and ask the router to setup default routes like this:
+
+```ruby
+::ActionSubscriber.draw_routes do
+  default_routes_for ::UserSubscriber
+  default_routes_for ::NotificationSubscriber
+end
+```
+
+This is the easiest migration path for existing users to follow, but it doesn't allow for things like mixing which exchange you are subscribing to between different actions.
+
+## Custom Routes
+
+You can also specify custom routes for your subscribers when you want more flexibility.
+
+```ruby
+::ActionSubscriber.draw_routes do
+  default_routes_for ::UserSubscriber
+
+  route ::NotificationSubscriber, :created, :publisher => :newman, :exchange => :events
+  route ::NotificationSubscriber, :send, :publisher => :newman, :exchange => :action
+end
+```
+
+## Options For Routes
+
+The `route` method supports the following options:
+
+* `acknowledgements` this toggles whether this route is expected to provide an acknowledgment (default `false`)
+  * This is the equivalent of calling `at_most_once!`, `at_least_once!` or `manual_acknowledgement!` in your subscriber class
+* `exchange` specify which exchange you expect messages to be published to (default `"events"`)
+  * This is the equivalent of calling `exchange :actions` in your subscriber
+* `publisher` this will prefix your queue and routing key with the publishers name
+  * This is the equivalent of puting `publisher :foo` in your subscriber
+* `queue` specifies which queue you will subscribe to rather than letting ActionSubscriber infer it from the name of the subscriber and action
+* `routing_key` specifies the routing key that will be bound to your queue
+
+<h3 id="footnotes">Footnotes</h3>
+
+* __1__ the old behavior of discovering and inferring routes for subscribers will be supported until the 2.0 version of ActionSubscriber. When no routes are drawn before calling `setup_queues!` we will print a deprecation warning and infer the routes for you.

--- a/spec/lib/action_subscriber/dsl_spec.rb
+++ b/spec/lib/action_subscriber/dsl_spec.rb
@@ -9,10 +9,6 @@ describe ::ActionSubscriber::DSL do
       it "acknowledges messages" do
         expect(subscriber.acknowledge_messages?).to eq(true)
       end
-
-      it "returns expected queue subscription options" do
-        expect(subscriber.queue_subscription_options).to eq( :manual_ack => true )
-      end
     end
 
     context "when at_most_once! is set" do

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -1,7 +1,7 @@
 describe ActionSubscriber::Router do
-  it "can specify basic routes" do
-    class FakeSubscriber; end
+  class FakeSubscriber; end
 
+  it "can specify basic routes" do
     routes = described_class.draw_routes do
       route FakeSubscriber, :foo
     end
@@ -15,8 +15,6 @@ describe ActionSubscriber::Router do
   end
 
   it "can specify a publisher" do
-    class FakeSubscriber; end
-
     routes = described_class.draw_routes do
       route FakeSubscriber, :bluff, :publisher => :amigo
     end
@@ -30,8 +28,6 @@ describe ActionSubscriber::Router do
   end
 
   it "can specify an exchange" do
-    class FakeSubscriber; end
-
     routes = described_class.draw_routes do
       route FakeSubscriber, :crashed, :exchange => :actions
     end
@@ -45,8 +41,6 @@ describe ActionSubscriber::Router do
   end
 
   it "can specify acknowledgements" do
-    class FakeSubscriber; end
-
     routes = described_class.draw_routes do
       route FakeSubscriber, :foo, :acknowledgements => true
     end
@@ -60,8 +54,6 @@ describe ActionSubscriber::Router do
   end
 
   it "can specify the queue" do
-    class FakeSubscriber; end
-
     routes = described_class.draw_routes do
       route FakeSubscriber, :foo, :publisher => "russell", :queue => "i-am-your-father"
     end
@@ -75,8 +67,6 @@ describe ActionSubscriber::Router do
   end
 
   it "can specify the routing key" do
-    class FakeSubscriber; end
-
     routes = described_class.draw_routes do
       route FakeSubscriber, :foo, :publisher => "russell", :routing_key => "make.it.so"
     end
@@ -87,5 +77,34 @@ describe ActionSubscriber::Router do
     expect(routes.first.routing_key).to eq("make.it.so")
     expect(routes.first.subscriber).to eq(FakeSubscriber)
     expect(routes.first.queue).to eq("alice.russell.fake.foo")
+  end
+
+  it "can infer routes based on the default routing rules" do
+    class SparkleSubscriber < ::ActionSubscriber::Base
+      at_most_once!
+      publisher :tommy
+      exchange :party
+
+      def bright; end
+      def dim; end
+    end
+
+    routes = described_class.draw_routes do
+      default_routes_for SparkleSubscriber
+    end
+
+    expect(routes.size).to eq(2)
+    expect(routes.first.acknowledgements).to eq(true)
+    expect(routes.first.action).to eq(:bright)
+    expect(routes.first.exchange).to eq("party")
+    expect(routes.first.routing_key).to eq("tommy.sparkle.bright")
+    expect(routes.first.subscriber).to eq(SparkleSubscriber)
+    expect(routes.first.queue).to eq("alice.tommy.sparkle.bright")
+    expect(routes.last.acknowledgements).to eq(true)
+    expect(routes.last.action).to eq(:dim)
+    expect(routes.last.exchange).to eq("party")
+    expect(routes.last.routing_key).to eq("tommy.sparkle.dim")
+    expect(routes.last.subscriber).to eq(SparkleSubscriber)
+    expect(routes.last.queue).to eq("alice.tommy.sparkle.dim")
   end
 end

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -1,0 +1,91 @@
+describe ActionSubscriber::Router do
+  it "can specify basic routes" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :foo
+    end
+
+    expect(routes.first.acknowledgements).to eq(false)
+    expect(routes.first.action).to eq(:foo)
+    expect(routes.first.exchange).to eq("events")
+    expect(routes.first.routing_key).to eq("fake.foo")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("alice.fake.foo")
+  end
+
+  it "can specify a publisher" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :bluff, :publisher => :amigo
+    end
+
+    expect(routes.first.acknowledgements).to eq(false)
+    expect(routes.first.action).to eq(:bluff)
+    expect(routes.first.exchange).to eq("events")
+    expect(routes.first.routing_key).to eq("amigo.fake.bluff")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("alice.amigo.fake.bluff")
+  end
+
+  it "can specify an exchange" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :crashed, :exchange => :actions
+    end
+
+    expect(routes.first.acknowledgements).to eq(false)
+    expect(routes.first.action).to eq(:crashed)
+    expect(routes.first.exchange).to eq("actions")
+    expect(routes.first.routing_key).to eq("fake.crashed")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("alice.fake.crashed")
+  end
+
+  it "can specify acknowledgements" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :foo, :acknowledgements => true
+    end
+
+    expect(routes.first.acknowledgements).to eq(true)
+    expect(routes.first.action).to eq(:foo)
+    expect(routes.first.exchange).to eq("events")
+    expect(routes.first.routing_key).to eq("fake.foo")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("alice.fake.foo")
+  end
+
+  it "can specify the queue" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :foo, :publisher => "russell", :queue => "i-am-your-father"
+    end
+
+    expect(routes.first.acknowledgements).to eq(false)
+    expect(routes.first.action).to eq(:foo)
+    expect(routes.first.exchange).to eq("events")
+    expect(routes.first.routing_key).to eq("russell.fake.foo")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("i-am-your-father")
+  end
+
+  it "can specify the routing key" do
+    class FakeSubscriber; end
+
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :foo, :publisher => "russell", :routing_key => "make.it.so"
+    end
+
+    expect(routes.first.acknowledgements).to eq(false)
+    expect(routes.first.action).to eq(:foo)
+    expect(routes.first.exchange).to eq("events")
+    expect(routes.first.routing_key).to eq("make.it.so")
+    expect(routes.first.subscriber).to eq(FakeSubscriber)
+    expect(routes.first.queue).to eq("alice.russell.fake.foo")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,7 @@ RSpec.configure do |config|
   end
   config.after(:each, :integration => true) do
     ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
-    ::ActionSubscriber::Base.inherited_classes.each do |klass|
-      klass.instance_variable_set("@_queues", nil)
-    end
+    ::ActionSubscriber.instance_variable_set("@route_set", nil)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
     ::ActionSubscriber.setup_queues!
   end
   config.after(:each, :integration => true) do
+    ::ActionSubscriber.stop_subscribers!
     ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
     ::ActionSubscriber.instance_variable_set("@route_set", nil)
   end


### PR DESCRIPTION
:warning: :warning: use this [diff link](https://github.com/mxenabled/action_subscriber/compare/routes...explicit_routes) until #34 is merged :warning: :warning:

This is a new feature that deprecates the old `DefaultRouting` mixin for the subscribers. Instead of having the library discover subscribers and infer their routes, we are going to let the application draw their own routes similar to Rails' `config/routes.rb` file.

The `routing.md` file has some examples and more explanation, but here is a simple example to whet your appetite.
```ruby
ActionSubscriber.draw_routes do
  default_routes_for ::UserSubscriber
  route ::AccountSubscriber, :created, :publisher => :abacus, :exchange => :events
  route ::AccountSubscriber, :refresh, :publisher => "*", :exchange => :actions
end
```

/cc @abrandoned @localshred @liveh2o @brettallred 