### PR TITLE
Prefetch per route

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -37,7 +37,7 @@ module ActionSubscriber
       def auto_subscribe!
         queues.each do |route, queue|
           channel = queue.channel
-          channel.prefetch(::ActionSubscriber.config.prefetch) if route.acknowledgements?
+          channel.prefetch(route.prefetch) if route.acknowledgements?
           consumer = ::Bunny::Consumer.new(channel, queue, channel.generate_consumer_tag, !route.acknowledgements?)
           consumer.on_delivery do |delivery_info, properties, encoded_payload|
             ::ActiveSupport::Notifications.instrument "received_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -35,7 +35,7 @@ module ActionSubscriber
 
       def auto_subscribe!
         queues.each do |route,queue|
-          queue.channel.prefetch = ::ActionSubscriber.config.prefetch if route.acknowledgements?
+          queue.channel.prefetch = route.prefetch if route.acknowledgements?
           consumer = queue.subscribe(route.queue_subscription_options) do |metadata, encoded_payload|
             ::ActiveSupport::Notifications.instrument "received_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name
             properties = {

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -3,6 +3,7 @@ module ActionSubscriber
     attr_reader :acknowledgements,
                 :action,
                 :exchange,
+                :prefetch,
                 :routing_key,
                 :subscriber,
                 :queue
@@ -11,6 +12,7 @@ module ActionSubscriber
       @acknowledgements = attributes.fetch(:acknowledgements)
       @action = attributes.fetch(:action)
       @exchange = attributes.fetch(:exchange).to_s
+      @prefetch = attributes.fetch(:prefetch) { ::ActionSubscriber.config.prefetch }
       @routing_key = attributes.fetch(:routing_key)
       @subscriber = attributes.fetch(:subscriber)
       @queue = attributes.fetch(:queue)

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -53,6 +53,16 @@ describe ActionSubscriber::Router do
     expect(routes.first.queue).to eq("alice.fake.foo")
   end
 
+  it "can specify a prefetch value" do
+    routes = described_class.draw_routes do
+      route FakeSubscriber, :foo, :acknowledgements => true, :prefetch => 10
+      route FakeSubscriber, :bar, :acknowledgements => true
+    end
+
+    expect(routes.first.prefetch).to eq(10)
+    expect(routes.last.prefetch).to eq(::ActionSubscriber.config.prefetch)
+  end
+
   it "can specify the queue" do
     routes = described_class.draw_routes do
       route FakeSubscriber, :foo, :publisher => "russell", :queue => "i-am-your-father"


### PR DESCRIPTION
We have a case in one of our subscribers where the average time to process one job type is MUCH longer than other types (30sec avg vs 10ms avg). Because of this disparity we would like to have that route prefetch much fewer messages than the other routes. This will help to avoid that queue getting backed up waiting for acknowledgements on a busy server.

This new feature just allows us to set a `prefetch` on a specific route when we are manually drawing the routes. It results in a set of channels like this:
![screen shot 2015-12-03 at 4 58 37 pm](https://cloud.githubusercontent.com/assets/80008/11578076/72443126-99df-11e5-9c90-bc677e396446.png)

/cc @ztoolson @liveh2o @brianstien @abrandoned @quixoten 