### PR TITLE
use ActionSubscriber::Publisher for all publishing in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
  - 2.1
  - 2.2
  - jruby-1.7
- - jruby-9.0.1.0
+ - jruby-9.0.4.0
  - jruby-head
  - rbx-2
 services:

--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -22,15 +22,12 @@ class InstaSubscriber < ActionSubscriber::Base
 end
 
 describe "subscriber filters", :integration => true do
-  let(:connection) { subscriber.connection }
   let(:subscriber) { InstaSubscriber }
 
   it "runs multiple around filters" do
     $messages = []  #testing the order of things
     ::ActionSubscriber.auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("hEY Guyz!", :routing_key => "insta.first")
+    ::ActionSubscriber::Publisher.publish("insta.first", "hEY Guyz!", "events")
 
     verify_expectation_within(1.0) do
       expect($messages).to eq [:whisper_before, :yell_before, "hEY Guyz!", :yell_after, :whisper_after]

--- a/spec/integration/at_least_once_spec.rb
+++ b/spec/integration/at_least_once_spec.rb
@@ -8,14 +8,11 @@ class GorbyPuffSubscriber < ActionSubscriber::Base
 end
 
 describe "at_least_once! mode", :integration => true do
-  let(:connection) { subscriber.connection }
   let(:subscriber) { GorbyPuffSubscriber }
 
   it "retries a failed job until it succeeds" do
     ::ActionSubscriber.auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("GrumpFace", :routing_key => "gorby_puff.grumpy")
+    ::ActionSubscriber::Publisher.publish("gorby_puff.grumpy", "GrumpFace", "events")
 
     verify_expectation_within(2.0) do
       expect($messages).to eq Set.new(["GrumpFace::0","GrumpFace::1","GrumpFace::2"])

--- a/spec/integration/at_most_once_spec.rb
+++ b/spec/integration/at_most_once_spec.rb
@@ -8,14 +8,11 @@ class PokemonSubscriber < ActionSubscriber::Base
 end
 
 describe "at_most_once! mode", :integration => true do
-  let(:connection) { subscriber.connection }
   let(:subscriber) { PokemonSubscriber }
 
   it "does not retry a failed message" do
     ::ActionSubscriber.auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("All Pokemon have been caught", :routing_key => "pokemon.caught_em_all")
+    ::ActionSubscriber::Publisher.publish("pokemon.caught_em_all", "All Pokemon have been caught", "events")
 
     verify_expectation_within(1.0) do
       expect($messages.size).to eq 1

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -13,9 +13,7 @@ describe "Automatically reconnect on connection failure", :integration => true, 
 
   it "reconnects when a connection drops" do
     ::ActionSubscriber::auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("First", :routing_key => "gus.spoke")
+    ::ActionSubscriber::Publisher.publish("gus.spoke", "First", "events")
     verify_expectation_within(5.0) do
       expect($messages).to eq(Set.new(["First"]))
     end
@@ -26,9 +24,7 @@ describe "Automatically reconnect on connection failure", :integration => true, 
       expect(connection).to be_open
     end
 
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("Second", :routing_key => "gus.spoke")
+    ::ActionSubscriber::Publisher.publish("gus.spoke", "Second", "events")
     verify_expectation_within(5.0) do
       expect($messages).to eq(Set.new(["First", "Second"]))
     end

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -34,10 +34,8 @@ describe "A Basic Subscriber", :integration => true do
   context "ActionSubscriber.auto_subscribe!" do
     it "routes messages to the right place" do
       ::ActionSubscriber.auto_subscribe!
-      channel = connection.create_channel
-      exchange = channel.topic("events")
-      exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
-      exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
+      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
+      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
 
       verify_expectation_within(2.0) do
         expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))

--- a/spec/integration/decoding_payloads_spec.rb
+++ b/spec/integration/decoding_payloads_spec.rb
@@ -15,9 +15,7 @@ describe "Payload Decoding", :integration => true do
 
   it "decodes json by default" do
     ::ActionSubscriber.auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => "application/json")
+    ::ActionSubscriber::Publisher.publish("twitter.tweet", json_string, "events", :content_type => "application/json")
 
     verify_expectation_within(2.0) do
       expect($messages).to eq Set.new([{
@@ -35,9 +33,7 @@ describe "Payload Decoding", :integration => true do
 
     it "it decodes the payload using the custom decoder" do
       ::ActionSubscriber.auto_subscribe!
-      channel = connection.create_channel
-      exchange = channel.topic("events")
-      exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => content_type)
+      ::ActionSubscriber::Publisher.publish("twitter.tweet", json_string, "events", :content_type => content_type)
 
       verify_expectation_within(2.0) do
         expect($messages).to eq Set.new([{

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -17,9 +17,7 @@ describe "Manual Message Acknowledgment", :integration => true do
 
   it "retries rejected messages and stops retrying acknowledged messages" do
     ::ActionSubscriber.auto_subscribe!
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("BACON!", :routing_key => "bacon.served")
+    ::ActionSubscriber::Publisher.publish("bacon.served", "BACON!", "events")
 
     verify_expectation_within(2.0) do
       expect($messages).to eq(Set.new(["BACON!::0", "BACON!::1", "BACON!::2"]))


### PR DESCRIPTION
This changes our integration tests to use `ActionSubscriber::Publisher.publish` rather than manually grabbing connection objects and doing publishing. No behavioral changes here, just a refactoring to make the tests easier to understand.

/cc @film42 @localshred @quixoten @liveh2o 