### PR TITLE
Draw routes for tests

### DIFF
--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -22,6 +22,11 @@ class InstaSubscriber < ActionSubscriber::Base
 end
 
 describe "subscriber filters", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for InstaSubscriber
+    end
+  end
   let(:subscriber) { InstaSubscriber }
 
   it "runs multiple around filters" do

--- a/spec/integration/at_least_once_spec.rb
+++ b/spec/integration/at_least_once_spec.rb
@@ -8,6 +8,11 @@ class GorbyPuffSubscriber < ActionSubscriber::Base
 end
 
 describe "at_least_once! mode", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for GorbyPuffSubscriber
+    end
+  end
   let(:subscriber) { GorbyPuffSubscriber }
 
   it "retries a failed job until it succeeds" do

--- a/spec/integration/at_most_once_spec.rb
+++ b/spec/integration/at_most_once_spec.rb
@@ -8,6 +8,11 @@ class PokemonSubscriber < ActionSubscriber::Base
 end
 
 describe "at_most_once! mode", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for PokemonSubscriber
+    end
+  end
   let(:subscriber) { PokemonSubscriber }
 
   it "does not retry a failed message" do

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -8,6 +8,11 @@ end
 
 describe "Automatically reconnect on connection failure", :integration => true, :slow => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for GusSubscriber
+    end
+  end
   let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
   let(:subscriber) { GusSubscriber }
 

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -1,37 +1,23 @@
 class BasicPushSubscriber < ActionSubscriber::Base
-  publisher :greg
-
-  # queue => alice.greg.basic_push.booked
-  # routing_key => greg.basic_push.booked
   def booked
-    $messages << payload
-  end
-
-  queue_for :cancelled, "basic.cancelled"
-  routing_key_for :cancelled, "basic.cancelled"
-
-  def cancelled
     $messages << payload
   end
 end
 
 describe "A Basic Subscriber", :integration => true do
-  let(:connection) { subscriber.connection }
   let(:draw_routes) do
     ::ActionSubscriber.draw_routes do
-      default_routes_for ::BasicPushSubscriber
+      route ::BasicPushSubscriber, :booked
     end
   end
-  let(:subscriber) { BasicPushSubscriber }
 
   context "ActionSubscriber.auto_pop!" do
     it "routes messages to the right place" do
-      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
-      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
+      ::ActionSubscriber::Publisher.publish("basic_push.booked", "Ohai Booked", "events")
 
       verify_expectation_within(2.0) do
         ::ActionSubscriber.auto_pop!
-        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+        expect($messages).to eq(Set.new(["Ohai Booked"]))
       end
     end
   end
@@ -39,11 +25,10 @@ describe "A Basic Subscriber", :integration => true do
   context "ActionSubscriber.auto_subscribe!" do
     it "routes messages to the right place" do
       ::ActionSubscriber.auto_subscribe!
-      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
-      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
+      ::ActionSubscriber::Publisher.publish("basic_push.booked", "Ohai Booked", "events")
 
       verify_expectation_within(2.0) do
-        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+        expect($messages).to eq(Set.new(["Ohai Booked"]))
       end
     end
   end

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -17,6 +17,11 @@ end
 
 describe "A Basic Subscriber", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for ::BasicPushSubscriber
+    end
+  end
   let(:subscriber) { BasicPushSubscriber }
 
   context "ActionSubscriber.auto_pop!" do

--- a/spec/integration/custom_headers_spec.rb
+++ b/spec/integration/custom_headers_spec.rb
@@ -7,6 +7,11 @@ class PrankSubscriber < ActionSubscriber::Base
 end
 
 describe "Custom Headers Are Published and Received", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for PrankSubscriber
+    end
+  end
   let(:headers) { { "Custom" => "content/header" } }
 
   it "works for auto_pop!" do

--- a/spec/integration/decoding_payloads_spec.rb
+++ b/spec/integration/decoding_payloads_spec.rb
@@ -10,6 +10,11 @@ end
 
 describe "Payload Decoding", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for TwitterSubscriber
+    end
+  end
   let(:subscriber) { TwitterSubscriber }
   let(:json_string) { '{"foo": "bar"}' }
 

--- a/spec/integration/inferred_routes_spec.rb
+++ b/spec/integration/inferred_routes_spec.rb
@@ -1,0 +1,46 @@
+class InferenceSubscriber < ActionSubscriber::Base
+  publisher :kyle
+
+  def yo
+    $messages << payload
+  end
+
+  queue_for :hey, "some_other_queue.hey"
+  routing_key_for :hey, "other_routing_key.hey"
+  def hey
+    $messages << payload
+  end
+end
+
+describe "A Subscriber With Inferred Routes", :integration => true do
+  context "explicit routing with default_routes_for helper" do
+    let(:draw_routes) do
+      ::ActionSubscriber.draw_routes do
+        default_routes_for InferenceSubscriber
+      end
+    end
+
+    it "registers the routes and sets up the queues" do
+      ::ActionSubscriber.auto_subscribe!
+      ::ActionSubscriber::Publisher.publish("kyle.inference.yo", "YO", "events")
+      ::ActionSubscriber::Publisher.publish("other_routing_key.hey", "HEY", "events")
+
+      verify_expectation_within(2.0) do
+        expect($messages).to eq(Set.new(["YO","HEY"]))
+      end
+    end
+  end
+
+  # This is the deprecated behavior we want to keep until version 2.0
+  context "no explicit routes" do
+    it "registers the routes and sets up the queues" do
+      ::ActionSubscriber.auto_subscribe!
+      ::ActionSubscriber::Publisher.publish("kyle.inference.yo", "YO", "events")
+      ::ActionSubscriber::Publisher.publish("other_routing_key.hey", "HEY", "events")
+
+      verify_expectation_within(2.0) do
+        expect($messages).to eq(Set.new(["YO","HEY"]))
+      end
+    end
+  end
+end

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -13,6 +13,11 @@ end
 
 describe "Manual Message Acknowledgment", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for BaconSubscriber
+    end
+  end
   let(:subscriber) { BaconSubscriber }
 
   it "retries rejected messages and stops retrying acknowledged messages" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
 
   config.before(:each, :integration => true) do
     $messages = Set.new
+    draw_routes if respond_to?(:draw_routes)
     ::ActionSubscriber::RabbitConnection.subscriber_connection
     ::ActionSubscriber.setup_queues!
   end


### PR DESCRIPTION
As we are working towards deprecating inferred routes I wanted to have the test suite draw explicit routes. I also added a new test which specifically doesn't draw its own routes to make sure we don't break this deprecated behavior until we are ready to cut 2.0.

This also makes it a lot easier for me to make the next change of supporting multiple threadpools.

/cc @quixoten @localshred @abrandoned @liveh2o 