### PR TITLE
Multiple threadpools

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -29,7 +29,7 @@ module ActionSubscriber
               :queue => queue.name,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
-            enqueue_env(env)
+            enqueue_env(route.threadpool, env)
           end
         end
       end
@@ -52,7 +52,7 @@ module ActionSubscriber
               :queue => queue.name,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
-            enqueue_env(env)
+            enqueue_env(route.threadpool, env)
           end
           bunny_consumers << consumer
           queue.subscribe_with(consumer)
@@ -61,8 +61,8 @@ module ActionSubscriber
 
       private
 
-      def enqueue_env(env)
-        ::ActionSubscriber::Threadpool.pool.async(env) do |env|
+      def enqueue_env(threadpool, env)
+        threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key do
             ::ActionSubscriber.config.middleware.call(env)
           end

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -25,7 +25,7 @@ module ActionSubscriber
               :queue => queue.name,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
-            enqueue_env(env)
+            enqueue_env(route.threadpool, env)
           end
         end
 
@@ -49,7 +49,7 @@ module ActionSubscriber
               :queue => queue.name,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
-            enqueue_env(env)
+            enqueue_env(route.threadpool, env)
           end
 
           march_hare_consumers << consumer
@@ -62,8 +62,8 @@ module ActionSubscriber
 
       private
 
-      def enqueue_env(env)
-        ::ActionSubscriber::Threadpool.pool.async(env) do |env|
+      def enqueue_env(threadpool, env)
+        threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key do
             ::ActionSubscriber.config.middleware.call(env)
           end

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -4,18 +4,20 @@ module ActionSubscriber
                 :action,
                 :exchange,
                 :prefetch,
+                :queue,
                 :routing_key,
                 :subscriber,
-                :queue
+                :threadpool
 
     def initialize(attributes)
       @acknowledgements = attributes.fetch(:acknowledgements)
       @action = attributes.fetch(:action)
       @exchange = attributes.fetch(:exchange).to_s
       @prefetch = attributes.fetch(:prefetch) { ::ActionSubscriber.config.prefetch }
+      @queue = attributes.fetch(:queue)
       @routing_key = attributes.fetch(:routing_key)
       @subscriber = attributes.fetch(:subscriber)
-      @queue = attributes.fetch(:queue)
+      @threadpool = attributes.fetch(:threadpool) { ::ActionSubscriber::Threadpool.pool(:default) }
     end
 
     def acknowledgements?

--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -22,6 +22,11 @@ class InstaSubscriber < ActionSubscriber::Base
 end
 
 describe "subscriber filters", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for InstaSubscriber
+    end
+  end
   let(:subscriber) { InstaSubscriber }
 
   it "runs multiple around filters" do

--- a/spec/integration/at_least_once_spec.rb
+++ b/spec/integration/at_least_once_spec.rb
@@ -8,6 +8,11 @@ class GorbyPuffSubscriber < ActionSubscriber::Base
 end
 
 describe "at_least_once! mode", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for GorbyPuffSubscriber
+    end
+  end
   let(:subscriber) { GorbyPuffSubscriber }
 
   it "retries a failed job until it succeeds" do

--- a/spec/integration/at_most_once_spec.rb
+++ b/spec/integration/at_most_once_spec.rb
@@ -8,6 +8,11 @@ class PokemonSubscriber < ActionSubscriber::Base
 end
 
 describe "at_most_once! mode", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for PokemonSubscriber
+    end
+  end
   let(:subscriber) { PokemonSubscriber }
 
   it "does not retry a failed message" do

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -8,6 +8,11 @@ end
 
 describe "Automatically reconnect on connection failure", :integration => true, :slow => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for GusSubscriber
+    end
+  end
   let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
   let(:subscriber) { GusSubscriber }
 

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -1,37 +1,23 @@
 class BasicPushSubscriber < ActionSubscriber::Base
-  publisher :greg
-
-  # queue => alice.greg.basic_push.booked
-  # routing_key => greg.basic_push.booked
   def booked
-    $messages << payload
-  end
-
-  queue_for :cancelled, "basic.cancelled"
-  routing_key_for :cancelled, "basic.cancelled"
-
-  def cancelled
     $messages << payload
   end
 end
 
 describe "A Basic Subscriber", :integration => true do
-  let(:connection) { subscriber.connection }
   let(:draw_routes) do
     ::ActionSubscriber.draw_routes do
-      default_routes_for ::BasicPushSubscriber
+      route ::BasicPushSubscriber, :booked
     end
   end
-  let(:subscriber) { BasicPushSubscriber }
 
   context "ActionSubscriber.auto_pop!" do
     it "routes messages to the right place" do
-      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
-      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
+      ::ActionSubscriber::Publisher.publish("basic_push.booked", "Ohai Booked", "events")
 
       verify_expectation_within(2.0) do
         ::ActionSubscriber.auto_pop!
-        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+        expect($messages).to eq(Set.new(["Ohai Booked"]))
       end
     end
   end
@@ -39,11 +25,10 @@ describe "A Basic Subscriber", :integration => true do
   context "ActionSubscriber.auto_subscribe!" do
     it "routes messages to the right place" do
       ::ActionSubscriber.auto_subscribe!
-      ::ActionSubscriber::Publisher.publish("greg.basic_push.booked", "Ohai Booked", "events")
-      ::ActionSubscriber::Publisher.publish("basic.cancelled", "Ohai Cancelled", "events")
+      ::ActionSubscriber::Publisher.publish("basic_push.booked", "Ohai Booked", "events")
 
       verify_expectation_within(2.0) do
-        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+        expect($messages).to eq(Set.new(["Ohai Booked"]))
       end
     end
   end

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -17,6 +17,11 @@ end
 
 describe "A Basic Subscriber", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for ::BasicPushSubscriber
+    end
+  end
   let(:subscriber) { BasicPushSubscriber }
 
   context "ActionSubscriber.auto_pop!" do

--- a/spec/integration/custom_headers_spec.rb
+++ b/spec/integration/custom_headers_spec.rb
@@ -7,6 +7,11 @@ class PrankSubscriber < ActionSubscriber::Base
 end
 
 describe "Custom Headers Are Published and Received", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for PrankSubscriber
+    end
+  end
   let(:headers) { { "Custom" => "content/header" } }
 
   it "works for auto_pop!" do

--- a/spec/integration/decoding_payloads_spec.rb
+++ b/spec/integration/decoding_payloads_spec.rb
@@ -10,6 +10,11 @@ end
 
 describe "Payload Decoding", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for TwitterSubscriber
+    end
+  end
   let(:subscriber) { TwitterSubscriber }
   let(:json_string) { '{"foo": "bar"}' }
 

--- a/spec/integration/inferred_routes_spec.rb
+++ b/spec/integration/inferred_routes_spec.rb
@@ -1,0 +1,46 @@
+class InferenceSubscriber < ActionSubscriber::Base
+  publisher :kyle
+
+  def yo
+    $messages << payload
+  end
+
+  queue_for :hey, "some_other_queue.hey"
+  routing_key_for :hey, "other_routing_key.hey"
+  def hey
+    $messages << payload
+  end
+end
+
+describe "A Subscriber With Inferred Routes", :integration => true do
+  context "explicit routing with default_routes_for helper" do
+    let(:draw_routes) do
+      ::ActionSubscriber.draw_routes do
+        default_routes_for InferenceSubscriber
+      end
+    end
+
+    it "registers the routes and sets up the queues" do
+      ::ActionSubscriber.auto_subscribe!
+      ::ActionSubscriber::Publisher.publish("kyle.inference.yo", "YO", "events")
+      ::ActionSubscriber::Publisher.publish("other_routing_key.hey", "HEY", "events")
+
+      verify_expectation_within(2.0) do
+        expect($messages).to eq(Set.new(["YO","HEY"]))
+      end
+    end
+  end
+
+  # This is the deprecated behavior we want to keep until version 2.0
+  context "no explicit routes" do
+    it "registers the routes and sets up the queues" do
+      ::ActionSubscriber.auto_subscribe!
+      ::ActionSubscriber::Publisher.publish("kyle.inference.yo", "YO", "events")
+      ::ActionSubscriber::Publisher.publish("other_routing_key.hey", "HEY", "events")
+
+      verify_expectation_within(2.0) do
+        expect($messages).to eq(Set.new(["YO","HEY"]))
+      end
+    end
+  end
+end

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -13,6 +13,11 @@ end
 
 describe "Manual Message Acknowledgment", :integration => true do
   let(:connection) { subscriber.connection }
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for BaconSubscriber
+    end
+  end
   let(:subscriber) { BaconSubscriber }
 
   it "retries rejected messages and stops retrying acknowledged messages" do

--- a/spec/integration/multiple_threadpools_spec.rb
+++ b/spec/integration/multiple_threadpools_spec.rb
@@ -1,0 +1,29 @@
+class DifferentThreadpoolsSubscriber < ActionSubscriber::Base
+  def one
+    $messages << payload
+  end
+
+  def two
+    $messages << payload
+  end
+end
+
+describe "Separate Threadpools for Different Message", :integration => true do
+  let(:draw_routes) do
+    low_priority_threadpool = ::ActionSubscriber::Threadpool.new_pool(:low_priority, 1)
+    ::ActionSubscriber.draw_routes do
+      route DifferentThreadpoolsSubscriber, :one
+      route DifferentThreadpoolsSubscriber, :two, :threadpool => low_priority_threadpool
+    end
+  end
+
+  it "processes messages in separate threadpools based on the routes" do
+    ::ActionSubscriber.auto_subscribe!
+    ::ActionSubscriber::Publisher.publish("different_threadpools.one", "ONE", "events")
+    ::ActionSubscriber::Publisher.publish("different_threadpools.two", "TWO", "events")
+
+    verify_expectation_within(2.0) do
+      expect($messages).to eq(Set.new(["ONE","TWO"]))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
 
   config.before(:each, :integration => true) do
     $messages = Set.new
+    draw_routes if respond_to?(:draw_routes)
     ::ActionSubscriber::RabbitConnection.subscriber_connection
     ::ActionSubscriber.setup_queues!
   end


### PR DESCRIPTION
:warning: :warning: __use [this diff link](https://github.com/mxenabled/action_subscriber/compare/draw_routes_for_tests...multiple_threadpools)__. This PR contains the changes from #40 as well.

This fixes #37. It allows an application to specify multiple threadpools of varying sizes and then direct different routes into those threadpools. This means that if you have routes with disparate latencies you can keep the fast jobs separate from the slow jobs. This also opens the door for us to deprecate the `--allow-low-priority-methods` flag. In the `2.0` release I would like to remove that feature and delete all of the code that is branching around that flag.

/cc @abrandoned @brettallred @liveh2o @localshred @quixoten 
