### PR TITLE
Logging

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -6,8 +6,6 @@ require 'thor'
 
 module ActionSubscriber
   class CLI < ::Thor
-    include ::ActionSubscriber::Logging
-
     class_option :allow_low_priority_methods, :type => :boolean, :desc => "subscribe to low priority queues in addition to the normal queues", :default => false
     class_option :app, :default => "./config/environment.rb"
     class_option :mode
@@ -28,10 +26,10 @@ module ActionSubscriber
       require options[:app]
 
       $0 = "Action Subscriber server #{object_id}"
-      logger.info "Loading configuration..."
+      ::ActionSubscriber.logger.info "Loading configuration..."
 
       ::ActionSubscriber::Configuration.configure_from_yaml_and_cli(options)
-      logger.info "Starting server..."
+      ::ActionSubscriber.logger.info "Starting server..."
 
       case ::ActionSubscriber.configuration.mode
       when /pop/i then

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -6,6 +6,8 @@ require 'thor'
 
 module ActionSubscriber
   class CLI < ::Thor
+    include ::ActionSubscriber::Logging
+
     class_option :allow_low_priority_methods, :type => :boolean, :desc => "subscribe to low priority queues in addition to the normal queues", :default => false
     class_option :app, :default => "./config/environment.rb"
     class_option :mode
@@ -26,10 +28,10 @@ module ActionSubscriber
       require options[:app]
 
       $0 = "Action Subscriber server #{object_id}"
-      puts "Loading configuration..."
+      logger.info "Loading configuration..."
 
       ::ActionSubscriber::Configuration.configure_from_yaml_and_cli(options)
-      puts "Starting server..."
+      logger.info "Starting server..."
 
       case ::ActionSubscriber.configuration.mode
       when /pop/i then

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -14,6 +14,7 @@ require "action_subscriber/version"
 require "action_subscriber/default_routing"
 require "action_subscriber/dsl"
 require "action_subscriber/configuration"
+require "action_subscriber/logging"
 require "action_subscriber/message_retry"
 require "action_subscriber/middleware"
 require "action_subscriber/rabbit_connection"
@@ -61,15 +62,19 @@ module ActionSubscriber
     @route_set = RouteSet.new(routes)
   end
 
+  def self.logger
+    ::ActionSubscriber::Logging.logger
+  end
+
   def self.print_subscriptions
-    puts configuration.inspect
+    logger.info configuration.inspect
     route_set.routes.group_by(&:subscriber).each do |subscriber, routes|
-      puts subscriber.name
+      logger.info subscriber.name
       routes.each do |route|
-        puts "  -- method: #{route.action}"
-        puts "    --    exchange: #{route.exchange}"
-        puts "    --       queue: #{route.queue}"
-        puts "    -- routing_key: #{route.routing_key}"
+        logger.info "  -- method: #{route.action}"
+        logger.info "    --    exchange: #{route.exchange}"
+        logger.info "    --       queue: #{route.queue}"
+        logger.info "    -- routing_key: #{route.routing_key}"
       end
     end
   end
@@ -112,7 +117,7 @@ module ActionSubscriber
   #
   def self.route_set
     @route_set ||= begin
-      puts "DEPRECATION WARNING: We are inferring your routes by looking at your subscribers. This behavior is deprecated and will be removed in version 2.0. Please see the routing guide at https://github.com/mxenabled/action_subscriber/blob/master/routing.md"
+      logger.warn "DEPRECATION WARNING: We are inferring your routes by looking at your subscribers. This behavior is deprecated and will be removed in version 2.0. Please see the routing guide at https://github.com/mxenabled/action_subscriber/blob/master/routing.md"
       RouteSet.new(self.send(:default_routes))
     end
   end

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -91,19 +91,20 @@ module ActionSubscriber
     end
 
     def self.stop_server!
-      logger.info "Stopping server..."
+      # this method is called from within a TRAP context so we can't use the logger
+      puts "Stopping server..."
       wait_loops = 0
       ::ActionSubscriber::Babou.stop_receving_messages!
 
       # Going to wait until the thread pool drains or we wait for 1000 seconds
       while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
-        logger.info "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
+        puts "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
         Thread.pass
         wait_loops = wait_loops + 1
         sleep 1
       end
 
-      logger.info "threadpool empty. Shutting down"
+      puts "threadpool empty. Shutting down"
     end
 
     def self.subscribers_loaded?

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -11,11 +11,11 @@ module ActionSubscriber
       sleep_time = ::ActionSubscriber.configuration.pop_interval.to_i / 1000.0
 
       ::ActionSubscriber.start_queues
-      logger.info "\nAction Subscriber is popping messages every #{sleep_time} seconds.\n"
+      logger.info "Action Subscriber is popping messages every #{sleep_time} seconds."
 
       # How often do we want the timer checking for new pops
       # since we included an eager popper we decreased the
-      # default check interval to 100ms
+      # default check interval to 100m
       while true
         ::ActionSubscriber.auto_pop! unless shutting_down?
         sleep sleep_time
@@ -33,7 +33,7 @@ module ActionSubscriber
       load_subscribers unless subscribers_loaded?
 
       ::ActionSubscriber.start_subscribers
-      logger.info "\nAction Subscriber connected\n"
+      logger.info "Action Subscriber connected"
 
       while true
         sleep 1.0 #just hang around waiting for messages

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -1,6 +1,8 @@
 module ActionSubscriber
   module Bunny
     module Subscriber
+      include ::ActionSubscriber::Logging
+
       def bunny_consumers
         @bunny_consumers ||= []
       end
@@ -62,6 +64,7 @@ module ActionSubscriber
       private
 
       def enqueue_env(threadpool, env)
+        logger.info "RECEIVED #{env.message_id} from #{env.queue}"
         threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key do
             ::ActionSubscriber.config.middleware.call(env)

--- a/lib/action_subscriber/logging.rb
+++ b/lib/action_subscriber/logging.rb
@@ -1,0 +1,27 @@
+# Taken from https://github.com/mperham/sidekiq/blob/7f882787e53d234042ff18099241403300a47585/lib/sidekiq/logging.rb
+require 'time'
+require 'logger'
+
+module ActionSubscriber
+  module Logging
+    def self.initialize_logger(log_target = STDOUT)
+      oldlogger = defined?(@logger) ? @logger : nil
+      @logger = Logger.new(log_target)
+      @logger.level = Logger::INFO
+      oldlogger.close if oldlogger && !$TESTING # don't want to close testing's STDOUT logging
+      @logger
+    end
+
+    def self.logger
+      defined?(@logger) ? @logger : initialize_logger
+    end
+
+    def self.logger=(log)
+      @logger = (log ? log : Logger.new('/dev/null'))
+    end
+
+    def logger
+      Sidekiq::Logging.logger
+    end
+  end
+end

--- a/lib/action_subscriber/logging.rb
+++ b/lib/action_subscriber/logging.rb
@@ -21,7 +21,7 @@ module ActionSubscriber
     end
 
     def logger
-      Sidekiq::Logging.logger
+      ::ActionSubscriber::Logging.logger
     end
   end
 end

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -1,6 +1,8 @@
 module ActionSubscriber
   module MarchHare
     module Subscriber
+      include ::ActionSubscriber::Logging
+
       def cancel_consumers!
         march_hare_consumers.each(&:cancel)
       end
@@ -63,6 +65,7 @@ module ActionSubscriber
       private
 
       def enqueue_env(threadpool, env)
+        logger.info "RECEIVED #{env.message_id} from #{env.queue}"
         threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key do
             ::ActionSubscriber.config.middleware.call(env)

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 module ActionSubscriber
   module Middleware
     class Env
@@ -30,7 +32,7 @@ module ActionSubscriber
         @encoded_payload = encoded_payload
         @exchange = properties.fetch(:exchange)
         @headers = properties.fetch(:headers) || {}
-        @message_id = properties.fetch(:message_id) || ::Random.new.bytes(3).unpack("H*")[0]
+        @message_id = properties.fetch(:message_id) || ::SecureRandom.hex(3)
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -30,7 +30,7 @@ module ActionSubscriber
         @encoded_payload = encoded_payload
         @exchange = properties.fetch(:exchange)
         @headers = properties.fetch(:headers) || {}
-        @message_id = properties.fetch(:message_id)
+        @message_id = properties.fetch(:message_id) || ::Random.new.bytes(3).unpack("H*")[0]
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -1,6 +1,8 @@
 module ActionSubscriber
   module Middleware
     class ErrorHandler
+      include ::ActionSubscriber::Logging
+
       def initialize(app)
         @app = app
       end
@@ -8,6 +10,7 @@ module ActionSubscriber
       def call(env)
         @app.call(env)
       rescue => error
+        logger.error "FAILED #{env.message_id}"
         ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
       end
     end

--- a/lib/action_subscriber/middleware/router.rb
+++ b/lib/action_subscriber/middleware/router.rb
@@ -1,12 +1,16 @@
 module ActionSubscriber
   module Middleware
     class Router
+      include ::ActionSubscriber::Logging
+
       def initialize(app)
         @app = app
       end
 
       def call(env)
+        logger.info "START #{env.message_id}"
         env.subscriber.run_action_with_filters(env, env.action)
+        logger.info "FINISHED #{env.message_id}"
       end
     end
   end

--- a/lib/action_subscriber/middleware/router.rb
+++ b/lib/action_subscriber/middleware/router.rb
@@ -8,7 +8,7 @@ module ActionSubscriber
       end
 
       def call(env)
-        logger.info "START #{env.message_id}"
+        logger.info "START #{env.message_id} #{env.subscriber}##{env.action}"
         env.subscriber.run_action_with_filters(env, env.action)
         logger.info "FINISHED #{env.message_id}"
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,10 @@ require 'active_record'
 
 # Require spec support files
 require 'support/user_subscriber'
-
 require 'action_subscriber/rspec'
+
+# Silence the Logger
+::ActionSubscriber::Logging.initialize_logger(nil)
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
Fixes #25 

We have needed logging for a long time, so let's get this done. I lifted the `Logging` class from sidekiq and removed a bunch of stuff that I don't think we need (at least initially) like multiple custom formatters, re-opening logger objects when receiving `USR2` signals etc.

Then I changed most of the `puts` statements in `bin/action_subscriber`, `lib/action_subscriber.rb` and `lib/action_subscriber/babou.rb` to use the new logger. Finally I added a little bit of logging for when we receive messages from Rabbitmq, when we start processing those messages, when we finish processing them and when a message fails to process.

Then I tested it under both MRI and jRuby. Fixed an edge case where you can't use a `Logger` when being called from a `trap` context and I ended up with output looking like this:
![screen shot 2015-12-23 at 11 00 18 am](https://cloud.githubusercontent.com/assets/80008/11981956/7885c3e4-a964-11e5-8855-14dd95b740e2.png)

/cc @film42 @abrandoned @localshred @liveh2o @brianstien 