### PR TITLE
Better default values

### DIFF
--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -96,8 +96,7 @@ module ActionSubscriber
       wait_loops = 0
       ::ActionSubscriber::Babou.stop_receving_messages!
 
-      # Going to wait until the thread pool drains or we wait for 1000 seconds
-      while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < 1000
+      while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
         puts "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
         Thread.pass
         wait_loops = wait_loops + 1

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -12,6 +12,7 @@ module ActionSubscriber
                   :port,
                   :prefetch,
                   :publisher_confirms,
+                  :seconds_to_wait_for_graceful_shutdown,
                   :threadpool_size,
                   :timeout,
                   :times_to_pop
@@ -25,8 +26,9 @@ module ActionSubscriber
       :mode => 'subscribe',
       :pop_interval => 100, # in milliseconds
       :port => 5672,
-      :prefetch => 200,
+      :prefetch => 5,
       :publisher_confirms => false,
+      :seconds_to_wait_for_graceful_shutdown => 30,
       :threadpool_size => 8,
       :timeout => 1,
       :times_to_pop => 8

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -7,7 +7,8 @@ describe ::ActionSubscriber::Configuration do
     specify { expect(subject.mode).to eq('subscribe') }
     specify { expect(subject.pop_interval).to eq(100) }
     specify { expect(subject.port).to eq(5672) }
-    specify { expect(subject.prefetch).to eq(200) }
+    specify { expect(subject.prefetch).to eq(5) }
+    specify { expect(subject.seconds_to_wait_for_graceful_shutdown).to eq(30) }
     specify { expect(subject.threadpool_size).to eq(8) }
     specify { expect(subject.timeout).to eq(1) }
     specify { expect(subject.times_to_pop).to eq(8) }


### PR DESCRIPTION
In our production environment we've switched the default `prefetch` to 5 across most of our subscribers and it has worked well for us. Prefetching 200 messages (per queue) means you end up holding onto a lot of messages and they can end up sitting around for a while before getting used.

If your message processing is in the 10ms+ range then prefetching that many messages does not actually speed things up so I've bumped the default down for the gem.

I've also setup a configuration value for how many seconds we should try to wait for the threadpool to drain during graceful shutdowns and defaulted it to 30 seconds (instead of the previous hardcoded 1000 seconds).

/cc @abrandoned @localshred @brettallred @brianstien @quixoten 