### PR TITLE
Fix Action Bug

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -21,6 +21,7 @@ module ActionSubscriber
             next unless encoded_payload # empty queue
             ::ActiveSupport::Notifications.instrument "popped_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name
             properties = {
+              :action => route.action,
               :channel => queue.channel,
               :content_type => properties[:content_type],
               :delivery_tag => delivery_info.delivery_tag,
@@ -44,6 +45,7 @@ module ActionSubscriber
           consumer.on_delivery do |delivery_info, properties, encoded_payload|
             ::ActiveSupport::Notifications.instrument "received_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name
             properties = {
+              :action => route.action,
               :channel => queue.channel,
               :content_type => properties.content_type,
               :delivery_tag => delivery_info.delivery_tag,

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -17,6 +17,7 @@ module ActionSubscriber
             next unless encoded_payload
             ::ActiveSupport::Notifications.instrument "popped_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name
             properties = {
+              :action => route.action,
               :channel => queue.channel,
               :content_type => metadata.content_type,
               :delivery_tag => metadata.delivery_tag,
@@ -41,6 +42,7 @@ module ActionSubscriber
           consumer = queue.subscribe(route.queue_subscription_options) do |metadata, encoded_payload|
             ::ActiveSupport::Notifications.instrument "received_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name
             properties = {
+              :action => route.action,
               :channel => queue.channel,
               :content_type => metadata.content_type,
               :delivery_tag => metadata.delivery_tag,

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -5,7 +5,8 @@ module ActionSubscriber
     class Env
       attr_accessor :payload
 
-      attr_reader :content_type,
+      attr_reader :action,
+                  :content_type,
                   :encoded_payload,
                   :exchange,
                   :headers,
@@ -26,6 +27,7 @@ module ActionSubscriber
       #         :message_id => String
       #         :routing_key => String
       def initialize(subscriber, encoded_payload, properties)
+        @action = properties.fetch(:action)
         @channel = properties.fetch(:channel)
         @content_type = properties.fetch(:content_type)
         @delivery_tag = properties.fetch(:delivery_tag)
@@ -41,13 +43,6 @@ module ActionSubscriber
       def acknowledge
         acknowledge_multiple_messages = false
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
-      end
-
-      # Return the last element of the routing key to indicate which action
-      # to route the payload to
-      #
-      def action
-        routing_key.split('.').last.to_s
       end
 
       def reject

--- a/lib/action_subscriber/rspec.rb
+++ b/lib/action_subscriber/rspec.rb
@@ -13,6 +13,7 @@ module ActionSubscriber
     end
 
     PROPERTIES_DEFAULTS = {
+      :action => :created,
       :channel => FakeChannel.new,
       :content_type => "text/plain",
       :delivery_tag => "XYZ",
@@ -71,6 +72,7 @@ end
     let(:app) { Proc.new { |inner_env| inner_env } }
     let(:env) { ActionSubscriber::Middleware::Env.new(UserSubscriber, 'encoded payload', message_properties) }
     let(:message_properties) {{
+      :action => :created,
       :channel => ::ActionSubscriber::RSpec::FakeChannel.new,
       :content_type => "text/plain",
       :delivery_tag => "XYZ",

--- a/spec/integration/custom_actions_spec.rb
+++ b/spec/integration/custom_actions_spec.rb
@@ -1,0 +1,24 @@
+class CustomActionSubscriber < ActionSubscriber::Base
+  def wat
+    $messages << payload
+  end
+end
+
+describe "A subscriber with a custom action", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      route ::CustomActionSubscriber, :wat,
+        :queue => "unrelated_to_the_action",
+        :routing_key => "*.javascript_framework"
+    end
+  end
+
+  it "routes the message to the selected action" do
+    ::ActionSubscriber.auto_subscribe!
+    ::ActionSubscriber::Publisher.publish("react.javascript_framework", "Another?!?!", "events")
+
+    verify_expectation_within(2.0) do
+      expect($messages).to eq(Set.new(["Another?!?!"]))
+    end
+  end
+end

--- a/spec/lib/action_subscriber/middleware/env_spec.rb
+++ b/spec/lib/action_subscriber/middleware/env_spec.rb
@@ -2,6 +2,7 @@ describe ActionSubscriber::Middleware::Env do
   let(:channel) { double("channel") }
   let(:encoded_payload) { 'encoded_payload' }
   let(:properties){ {
+    :action => :created,
     :channel => channel,
     :content_type => "application/json",
     :delivery_tag => "XYZ",
@@ -16,7 +17,7 @@ describe ActionSubscriber::Middleware::Env do
 
   subject { described_class.new(subscriber, encoded_payload, properties) }
 
-  specify { expect(subject.action).to eq("created") }
+  specify { expect(subject.action).to eq(:created) }
   specify { expect(subject.content_type).to eq(properties[:content_type]) }
   specify { expect(subject.exchange).to eq(properties[:exchange]) }
   specify { expect(subject.headers).to eq(properties[:headers]) }


### PR DESCRIPTION
There is an existing bug in ActionSubscriber where the user can setup a route with `action = :some_method`, but when messages are received it will use the last part of the `routing_key` instead of the action that was specific when the user was drawing their routes.

I'm almost positive this was an oversight when we built in the explicit routing layer because it is extremely surprising when you setup a route like `route ::AggregationSubscriber, :completed, ...`, but in production it tries to call `completed_low` because the routing key was specific as `grunt.aggregation.completed_low`.

/cc @abrandoned @brettallred @localshred @film42 @quixoten 