### PR TITLE
Add a durable asynchronous publisher

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -23,6 +23,7 @@ require "action_subscriber/bunny/subscriber"
 require "action_subscriber/march_hare/subscriber"
 require "action_subscriber/babou"
 require "action_subscriber/publisher"
+require "action_subscriber/publisher/async"
 require "action_subscriber/route"
 require "action_subscriber/route_set"
 require "action_subscriber/router"
@@ -109,6 +110,9 @@ module ActionSubscriber
 
   # Initialize config object
   config
+
+  # Intialize async publisher adapter
+  ::ActionSubscriber::Publisher::Async.publisher_adapter
 
   ::ActiveSupport.run_load_hooks(:action_subscriber, Base)
 

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -139,5 +139,6 @@ end
 require "action_subscriber/railtie" if defined?(Rails)
 
 at_exit do
+  ::ActionSubscriber::Publisher::Async.publisher_adapter.shutdown!
   ::ActionSubscriber::RabbitConnection.publisher_disconnect!
 end

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -2,6 +2,7 @@ module ActionSubscriber
   class Configuration
     attr_accessor :allow_low_priority_methods,
                   :async_message_publisher,
+                  :async_message_supervisor_interval,
                   :decoder,
                   :default_exchange,
                   :error_handler,
@@ -21,6 +22,7 @@ module ActionSubscriber
     DEFAULTS = {
       :allow_low_priority_methods => false,
       :async_message_publisher => 'memory',
+      :async_message_supervisor_interval => 200, # in milliseconds
       :default_exchange => 'events',
       :heartbeat => 5,
       :host => 'localhost',

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -1,8 +1,10 @@
 module ActionSubscriber
   class Configuration
     attr_accessor :allow_low_priority_methods,
-                  :async_message_publisher,
-                  :async_message_supervisor_interval,
+                  :async_publisher,
+                  :async_publisher_drop_messages_when_queue_full,
+                  :async_publisher_max_queue_size,
+                  :async_publisher_supervisor_interval,
                   :decoder,
                   :default_exchange,
                   :error_handler,
@@ -21,8 +23,10 @@ module ActionSubscriber
 
     DEFAULTS = {
       :allow_low_priority_methods => false,
-      :async_message_publisher => 'memory',
-      :async_message_supervisor_interval => 200, # in milliseconds
+      :async_publisher => 'memory',
+      :async_publisher_drop_messages_when_queue_full => false,
+      :async_publisher_max_queue_size => 1_000_000,
+      :async_publisher_supervisor_interval => 200, # in milliseconds
       :default_exchange => 'events',
       :heartbeat => 5,
       :host => 'localhost',

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -1,6 +1,7 @@
 module ActionSubscriber
   class Configuration
     attr_accessor :allow_low_priority_methods,
+                  :async_message_publisher_mode,
                   :decoder,
                   :default_exchange,
                   :error_handler,
@@ -19,6 +20,7 @@ module ActionSubscriber
 
     DEFAULTS = {
       :allow_low_priority_methods => false,
+      :async_message_publisher_mode => 'memory',
       :default_exchange => 'events',
       :heartbeat => 5,
       :host => 'localhost',

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -1,7 +1,7 @@
 module ActionSubscriber
   class Configuration
     attr_accessor :allow_low_priority_methods,
-                  :async_message_publisher_mode,
+                  :async_message_publisher,
                   :decoder,
                   :default_exchange,
                   :error_handler,
@@ -20,7 +20,7 @@ module ActionSubscriber
 
     DEFAULTS = {
       :allow_low_priority_methods => false,
-      :async_message_publisher_mode => 'memory',
+      :async_message_publisher => 'memory',
       :default_exchange => 'events',
       :heartbeat => 5,
       :host => 'localhost',

--- a/lib/action_subscriber/publisher/async.rb
+++ b/lib/action_subscriber/publisher/async.rb
@@ -1,0 +1,31 @@
+module ActionSubscriber
+  module Publisher
+    # Publish a message asynchronously to RabbitMQ.
+    #
+    # Asynchronous is designed to do two things:
+    # 1. Introduce the idea of a durable retry should the RabbitMQ connection disconnect.
+    # 2. Provide a higher-level pattern for fire-and-forget publishing.
+    #
+    # @param [String] route The routing key to use for this message.
+    # @param [String] payload The message you are sending. Should already be encoded as a string.
+    # @param [String] exchange The exchange you want to publish to.
+    # @param [Hash] options hash to set message parameters (e.g. headers).
+    def self.publish_async(route, payload, exchange_name, options = {})
+      Async.publisher_adapter.publish(route, payload, exchange_name, options)
+    end
+
+    module Async
+      def self.publisher_adapter
+        @publisher_adapter ||= case ::ActionSubscriber.configuration.async_message_publisher_mode
+                               when /memory/i then
+                                 require "action_subscriber/publisher/async/in_memory_adapter"
+                                 InMemoryAdapter.new
+                               when /redis/i then
+                                 fail "Not yet implemented"
+                               else
+                                 fail "Unknown async publisher provided"
+                               end
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/publisher/async.rb
+++ b/lib/action_subscriber/publisher/async.rb
@@ -16,7 +16,7 @@ module ActionSubscriber
 
     module Async
       def self.publisher_adapter
-        @publisher_adapter ||= case ::ActionSubscriber.configuration.async_message_publisher
+        @publisher_adapter ||= case ::ActionSubscriber.configuration.async_publisher
                                when /memory/i then
                                  require "action_subscriber/publisher/async/in_memory_adapter"
                                  InMemoryAdapter.new

--- a/lib/action_subscriber/publisher/async.rb
+++ b/lib/action_subscriber/publisher/async.rb
@@ -23,7 +23,7 @@ module ActionSubscriber
                                when /redis/i then
                                  fail "Not yet implemented"
                                else
-                                 fail "Unknown async publisher provided"
+                                 fail "Unknown adapter '#{::ActionSubscriber.configuration.async_publisher}' provided"
                                end
       end
     end

--- a/lib/action_subscriber/publisher/async.rb
+++ b/lib/action_subscriber/publisher/async.rb
@@ -16,7 +16,7 @@ module ActionSubscriber
 
     module Async
       def self.publisher_adapter
-        @publisher_adapter ||= case ::ActionSubscriber.configuration.async_message_publisher_mode
+        @publisher_adapter ||= case ::ActionSubscriber.configuration.async_message_publisher
                                when /memory/i then
                                  require "action_subscriber/publisher/async/in_memory_adapter"
                                  InMemoryAdapter.new

--- a/lib/action_subscriber/publisher/async/in_memory_adapter.rb
+++ b/lib/action_subscriber/publisher/async/in_memory_adapter.rb
@@ -87,7 +87,7 @@ module ActionSubscriber
                 @current_message = nil
               rescue *NETWORK_ERRORS
                 # Sleep because the connection is down.
-                sleep 1
+                sleep ::ActionSubscriber::RabbitConnection::NETWORK_RECOVERY_INTERVAL
                 # Requeue and try again.
                 queue.push(message)
               rescue => unknown_error

--- a/lib/action_subscriber/publisher/async/in_memory_adapter.rb
+++ b/lib/action_subscriber/publisher/async/in_memory_adapter.rb
@@ -34,112 +34,117 @@ module ActionSubscriber
             sleep 0.1
           end
         end
-      end
 
-      class Message
-        attr_reader :route, :payload, :exchange_name, :options
+        class Message
+          attr_reader :route, :payload, :exchange_name, :options
 
-        def initialize(route, payload, exchange_name, options)
-          @route = route
-          @payload = payload
-          @exchange_name = exchange_name
-          @options = options
-        end
-      end
-
-      class UnableToPersistMessageError < ::StandardError
-      end
-
-      class AsyncQueue
-        include ::ActionSubscriber::Logging
-
-        attr_reader :consumer, :queue, :supervisor
-
-        if ::RUBY_PLATFORM == "java"
-          NETWORK_ERRORS = [::MarchHare::Exception, ::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException].freeze
-        else
-          NETWORK_ERRORS = [::Bunny::Exception, ::Timeout::Error, ::IOError].freeze
+          def initialize(route, payload, exchange_name, options)
+            @route = route
+            @payload = payload
+            @exchange_name = exchange_name
+            @options = options
+          end
         end
 
-        def initialize
-          @queue = ::Queue.new
-          create_and_supervise_consumer!
+        class UnableToPersistMessageError < ::StandardError
         end
 
-        def push(message)
-          # Default of 1_000_000 messages.
-          if queue.size > ::ActionSubscriber.configuration.async_publisher_max_queue_size
-            # Drop Messages if the queue is full and we were configured to do so.
-            return if ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full
+        class AsyncQueue
+          include ::ActionSubscriber::Logging
 
-            # By default we will raise an error to push the responsibility onto the caller.
-            fail UnableToPersistMessageError, "Queue is full, messages will be dropped."
+          attr_reader :consumer, :queue, :supervisor
+
+          if ::RUBY_PLATFORM == "java"
+            NETWORK_ERRORS = [::MarchHare::Exception, ::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException].freeze
+          else
+            NETWORK_ERRORS = [::Bunny::Exception, ::Timeout::Error, ::IOError].freeze
           end
 
-          queue.push(message)
-        end
+          def initialize
+            @queue = ::Queue.new
+            create_and_supervise_consumer!
+          end
 
-        def size
-          queue.size
-        end
+          def push(message)
+            # Default of 1_000_000 messages.
+            if queue.size > ::ActionSubscriber.configuration.async_publisher_max_queue_size
+              # Drop Messages if the queue is full and we were configured to do so.
+              return if ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full
 
-      private
-
-        def create_and_supervise_consumer!
-          @consumer = create_consumer
-          @supervisor = ::Thread.new do
-            loop do
-              unless consumer.alive?
-                # Why might need to requeue the last message.
-                queue.push(@current_message) if @current_message.present?
-                consumer.kill
-                @consumer = create_consumer
-              end
-
-              # Pause before checking the consumer again.
-              sleep supervisor_interval
+              # By default we will raise an error to push the responsibility onto the caller.
+              fail UnableToPersistMessageError, "Queue is full, messages will be dropped."
             end
+
+            queue.push(message)
           end
-        end
 
-        def create_consumer
-          ::Thread.new do
-            loop do
-              # Write "current_message" so we can requeue should something happen to the consumer. I don't love this, but it's
-              # better than writing my own `#peek' method.
-              @current_message = message = queue.pop
+          def size
+            queue.size
+          end
 
-              begin
-                ::ActionSubscriber::Publisher.publish(message.route, message.payload, message.exchange_name, message.options)
+        private
 
-                # Reset
-                @current_message = nil
-              rescue *NETWORK_ERRORS
-                # Sleep because the connection is down.
-                sleep ::ActionSubscriber::RabbitConnection::NETWORK_RECOVERY_INTERVAL
-                # Requeue and try again.
-                queue.push(message)
-              rescue => unknown_error
-                # Do not requeue the message because something else horrible happened.
-                @current_message = nil
+          def await_network_reconnect
+            sleep ::ActionSubscriber::RabbitConnection::NETWORK_RECOVERY_INTERVAL
+          end
 
-                # Log the error.
-                logger.info unknown_error.class
-                logger.info unknown_error.message
-                logger.info unknown_error.backtrace.join("\n")
+          def create_and_supervise_consumer!
+            @consumer = create_consumer
+            @supervisor = ::Thread.new do
+              loop do
+                unless consumer.alive?
+                  # Why might need to requeue the last message.
+                  queue.push(@current_message) if @current_message.present?
+                  consumer.kill
+                  @consumer = create_consumer
+                end
 
-                # TODO: Find a way to bubble this out of the thread for logging purposes.
-                # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
-                raise unknown_error
+                # Pause before checking the consumer again.
+                sleep supervisor_interval
               end
             end
           end
-        end
 
-        def supervisor_interval
-          @supervisor_interval ||= begin
-            interval_in_milliseconds = ::ActionSubscriber.configuration.async_publisher_supervisor_interval
-            interval_in_milliseconds / 1000.0
+          def create_consumer
+            ::Thread.new do
+              loop do
+                # Write "current_message" so we can requeue should something happen to the consumer. I don't love this, but it's
+                # better than writing my own `#peek' method.
+                @current_message = message = queue.pop
+
+                begin
+                  ::ActionSubscriber::Publisher.publish(message.route, message.payload, message.exchange_name, message.options)
+
+                  # Reset
+                  @current_message = nil
+                rescue *NETWORK_ERRORS
+                  # Sleep because the connection is down.
+                  await_network_reconnect
+
+                  # Requeue and try again.
+                  queue.push(message)
+                rescue => unknown_error
+                  # Do not requeue the message because something else horrible happened.
+                  @current_message = nil
+
+                  # Log the error.
+                  logger.info unknown_error.class
+                  logger.info unknown_error.message
+                  logger.info unknown_error.backtrace.join("\n")
+
+                  # TODO: Find a way to bubble this out of the thread for logging purposes.
+                  # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
+                  raise unknown_error
+                end
+              end
+            end
+          end
+
+          def supervisor_interval
+            @supervisor_interval ||= begin
+              interval_in_milliseconds = ::ActionSubscriber.configuration.async_publisher_supervisor_interval
+              interval_in_milliseconds / 1000.0
+            end
           end
         end
       end

--- a/lib/action_subscriber/publisher/async/in_memory_adapter.rb
+++ b/lib/action_subscriber/publisher/async/in_memory_adapter.rb
@@ -1,0 +1,105 @@
+require "thread"
+
+module ActionSubscriber
+  module Publisher
+    module Async
+      class InMemoryAdapter
+        attr_reader :async_queue
+
+        def initialize
+          @async_queue = AsyncQueue.new
+        end
+
+        def publish(route, payload, exchange_name, options = {})
+          message = Message.new(route, payload, exchange_name, options)
+          async_queue.push(message)
+          nil
+        end
+      end
+
+      class Message
+        attr_reader :route, :payload, :exchange_name, :options
+
+        def initialize(route, payload, exchange_name, options)
+          @route = route
+          @payload = payload
+          @exchange_name = exchange_name
+          @options = options
+        end
+      end
+
+      class UnableToPersistMessageError < ::StandardError
+      end
+
+      class AsyncQueue
+        attr_reader :consumer, :queue, :supervisor
+
+        MAXIMUM_QUEUE_SIZE = 1_000_000.freeze
+
+        if ::RUBY_PLATFORM == "java"
+          NETWORK_ERRORS = [::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException]
+        else
+          NETWORK_ERRORS = [::Bunny::Exception, ::Timeout::Error, ::IOError]
+        end
+
+        def initialize
+          @queue = ::Queue.new
+          create_and_supervise_consumer!
+        end
+
+        def push(message)
+          # TODO: How do we exert backpressure here? Do we block the thread, or do we raise an error?
+          fail UnableToPersistMessageError, "Queue is full, messages will be dropped." if queue.size > MAXIMUM_QUEUE_SIZE
+
+          queue.push(message)
+        end
+
+      private
+
+        def create_and_supervise_consumer!
+          @consumer = create_consumer
+          @supervisor = ::Thread.new do
+            loop do
+              unless consumer.alive?
+                # Why might need to requeue the last message.
+                queue.push(@current_message) if @current_message.present?
+                consumer.kill
+                @consumer = create_consumer
+              end
+
+              # Pause before checking the consumer again.
+              sleep 1
+            end
+          end
+        end
+
+        def create_consumer
+          ::Thread.new do
+            loop do
+              # Write "current_message" so we can requeue should something happen to the consumer. I don't love this, but it's
+              # better than writing my own `#peek' method.
+              @current_message = message = queue.pop
+
+              begin
+                ::ActionSubscriber::Publisher.publish(message.route, message.payload, message.exchange_name, message.options)
+
+                # Reset
+                @current_message = nil
+              rescue *NETWORK_ERRORS
+                # Sleep because the connection is down.
+                sleep 1
+                # Requeue and try again.
+                queue.push(message)
+              rescue => unknown_error
+                # Do not requeue the message because something else horrible happened.
+                @current_message = nil
+                puts unknown_error.class
+                puts unknown_error.message
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -4,6 +4,7 @@ module ActionSubscriber
   module RabbitConnection
     SUBSCRIBER_CONNECTION_MUTEX = ::Mutex.new
     PUBLISHER_CONNECTION_MUTEX = ::Mutex.new
+    NETWORK_RECOVERY_INTERVAL = 1.freeze
 
     def self.publisher_connected?
       publisher_connection.try(:connected?)
@@ -66,7 +67,7 @@ module ActionSubscriber
         :port                          => ::ActionSubscriber.configuration.port,
         :continuation_timeout          => ::ActionSubscriber.configuration.timeout * 1_000.0, #convert sec to ms
         :automatically_recover         => true,
-        :network_recovery_interval     => 1,
+        :network_recovery_interval     => NETWORK_RECOVERY_INTERVAL,
         :recover_from_connection_close => true,
       }
     end

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -1,7 +1,10 @@
 describe ::ActionSubscriber::Configuration do
   describe "default values" do
     specify { expect(subject.allow_low_priority_methods).to eq(false) }
-    specify { expect(subject.default_exchange).to eq("events") }
+    specify { expect(subject.async_publisher).to eq("memory") }
+    specify { expect(subject.async_publisher_drop_messages_when_queue_full).to eq(false) }
+    specify { expect(subject.async_publisher_max_queue_size).to eq(1_000_000) }
+    specify { expect(subject.async_publisher_supervisor_interval).to eq(200) }
     specify { expect(subject.heartbeat).to eq(5) }
     specify { expect(subject.host).to eq("localhost") }
     specify { expect(subject.mode).to eq('subscribe') }

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -5,6 +5,7 @@ describe ::ActionSubscriber::Configuration do
     specify { expect(subject.async_publisher_drop_messages_when_queue_full).to eq(false) }
     specify { expect(subject.async_publisher_max_queue_size).to eq(1_000_000) }
     specify { expect(subject.async_publisher_supervisor_interval).to eq(200) }
+    specify { expect(subject.default_exchange).to eq("events") }
     specify { expect(subject.heartbeat).to eq(5) }
     specify { expect(subject.host).to eq("localhost") }
     specify { expect(subject.mode).to eq('subscribe') }

--- a/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
@@ -1,0 +1,135 @@
+describe ::ActionSubscriber::Publisher::Async::InMemoryAdapter do
+  let(:route) { "test" }
+  let(:payload) { "message" }
+  let(:exchange_name) { "place" }
+  let(:options) { { :test => :ok } }
+  let(:message) { described_class::Message.new(route, payload, exchange_name, options) }
+  let(:mock_queue) { double(:push => nil, :size => 0) }
+
+  describe "#publish" do
+    before do
+      allow(described_class::Message).to receive(:new).with(route, payload, exchange_name, options).and_return(message)
+      allow(described_class::AsyncQueue).to receive(:new).and_return(mock_queue)
+    end
+
+    it "can publish a message to the queue" do
+      expect(mock_queue).to receive(:push).with(message)
+      subject.publish(route, payload, exchange_name, options)
+    end
+  end
+
+  describe "#shutdown!" do
+    # This is called when the rspec finishes. I'm sure we can make this a better test.
+  end
+
+  describe "::ActionSubscriber::Publisher::Async::InMemoryAdapter::Message" do
+    specify { expect(message.route).to eq(route) }
+    specify { expect(message.payload).to eq(payload) }
+    specify { expect(message.exchange_name).to eq(exchange_name) }
+    specify { expect(message.options).to eq(options) }
+  end
+
+  describe "::ActionSubscriber::Publisher::Async::InMemoryAdapter::AsyncQueue" do
+    subject { described_class::AsyncQueue.new }
+
+    describe ".initialize" do
+      it "creates a supervisor" do
+        expect_any_instance_of(described_class::AsyncQueue).to receive(:create_and_supervise_consumer!)
+        subject
+      end
+    end
+
+    describe "#create_and_supervise_consumer!" do
+      it "creates a supervisor" do
+        expect_any_instance_of(described_class::AsyncQueue).to receive(:create_consumer)
+        subject
+      end
+
+      it "restarts the consumer when it dies" do
+        consumer = subject.consumer
+        consumer.kill
+
+        verify_expectation_within(0.1) do
+          expect(consumer).to_not be_alive
+        end
+
+        verify_expectation_within(0.3) do
+          expect(subject.consumer).to be_alive
+        end
+      end
+    end
+
+    describe "#create_consumer" do
+      it "can successfully publish a message" do
+        expect(::ActionSubscriber::Publisher).to receive(:publish).with(route, payload, exchange_name, options)
+        subject.push(message)
+        sleep 0.1 # Await results
+      end
+
+      context "when network error occurs" do
+        let(:error) { described_class::AsyncQueue::NETWORK_ERRORS.first }
+        before { allow(::ActionSubscriber::Publisher).to receive(:publish).and_raise(error) }
+
+        it "requeues the message" do
+          consumer = subject.consumer
+          expect(consumer).to be_alive
+          expect(subject).to receive(:await_network_reconnect).at_least(:once)
+          subject.push(message)
+          sleep 0.1 # Await results
+        end
+      end
+
+      context "when an unknown error occurs" do
+        before { allow(::ActionSubscriber::Publisher).to receive(:publish).and_raise(ArgumentError) }
+
+        it "kills the consumer" do
+          consumer = subject.consumer
+          expect(consumer).to be_alive
+          subject.push(message)
+          sleep 0.1 # Await results
+          expect(consumer).to_not be_alive
+        end
+      end
+    end
+
+    describe "#push" do
+      after { ::ActionSubscriber.configuration.async_publisher_max_queue_size = 1000 }
+      after { ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full = false }
+
+      context "when the queue has room" do
+        before { allow(::Queue).to receive(:new).and_return(mock_queue) }
+
+        it "successfully adds to the queue" do
+          expect(mock_queue).to receive(:push).with(message)
+          subject.push(message)
+        end
+      end
+
+      context "when the queue is full" do
+        before { ::ActionSubscriber.configuration.async_publisher_max_queue_size = -1 }
+
+        context "and we're dropping messages" do
+          before { ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full = true }
+
+          it "adding to the queue should not raise an error" do
+            expect { subject.push(message) }.to_not raise_error
+          end
+        end
+
+        context "and we're not dropping messages" do
+          before { ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full = false }
+
+          it "adding to the queue should raise error back to caller" do
+            expect { subject.push(message) }.to raise_error(described_class::UnableToPersistMessageError)
+          end
+        end
+      end
+    end
+
+    describe "#size" do
+      it "can return the size of the queue" do
+        expect(subject.size).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/lib/action_subscriber/publisher/async_spec.rb
+++ b/spec/lib/action_subscriber/publisher/async_spec.rb
@@ -1,0 +1,40 @@
+describe ::ActionSubscriber::Publisher::Async do
+
+  before { described_class.instance_variable_set(:@publisher_adapter, nil) }
+  after { ::ActionSubscriber.configuration.async_publisher = "memory" }
+
+  let(:mock_adapter) { double(:publish => nil) }
+
+  describe ".publish_async" do
+    before { allow(described_class).to receive(:publisher_adapter).and_return(mock_adapter) }
+
+    it "calls through the adapter" do
+      expect(mock_adapter).to receive(:publish).with("1", "2", "3", { "four" => "five" })
+      ::ActionSubscriber::Publisher.publish_async("1", "2", "3", { "four" => "five" })
+    end
+  end
+
+  context "when an in-memory adapter is selected" do
+    before { ::ActionSubscriber.configuration.async_publisher = "memory" }
+
+    it "Creates an in-memory publisher" do
+      expect(described_class.publisher_adapter).to be_an(::ActionSubscriber::Publisher::Async::InMemoryAdapter)
+    end
+  end
+
+  context "when an redis adapter is selected" do
+    before { ::ActionSubscriber.configuration.async_publisher = "redis" }
+
+    it "raises an error" do
+      expect { described_class.publisher_adapter }.to raise_error("Not yet implemented")
+    end
+  end
+
+  context "when some random adapter is selected" do
+    before { ::ActionSubscriber.configuration.async_publisher = "yolo" }
+
+    it "raises an error" do
+      expect { described_class.publisher_adapter }.to raise_error("Unknown adapter 'yolo' provided")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'support/user_subscriber'
 require 'action_subscriber/rspec'
 
 # Silence the Logger
+$TESTING = true
 ::ActionSubscriber::Logging.initialize_logger(nil)
 
 RSpec.configure do |config|


### PR DESCRIPTION
**What:**
This is a work-in-progress PR that allows you to pull message publishing into its own supervised thread. It's important to note that I'm not trying to change the `publish` code, instead I'm proposing to add a new layer of abstraction on top of it to add durability to message publishing. This PR will be the first of a few:

1. Establish a pattern for asynchronous message publishing (this PR).
2. Create a pattern that persists messages to disk (using redis).
3. Extract publisher code to its own gem.

With these changes, you will be able to durably and reliably publish messages without needing to rely on an immediately available RabbitMQ instance. For example, if you're publishing changes in your application's request path, a sick RabbitMQ cluster won't pose an immediate threat.

Writing these messages to disk is the main goal I'm trying to get to. I'm starting with an in-memory buffer because it's a simple default that we can ship in ActionSubscriber without needing to change our requirements. It also means that adding a redis layer becomes a simple configuration change. If you're not feeling too crazy about an in-memory buffer and think we should skip ahead to the redis version, please share your feedback.

Note: This doesn't include tests at this point, but those are coming. I want to make sure this looks like a good path forward before putting those up.

**Performance:**
Locally I can push ~500 1KB messages/sec on MRI, and ~900 1KB messages/sec on Jruby. I think these numbers are pretty good for a single-threaded publisher. If this becomes a problem, we can always create a pool of publishers.

cc @mmmries @abrandoned @liveh2o @brianstien @localshred 