### PR TITLE
Provide error handler to the async publisher

### DIFF
--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -103,6 +103,14 @@ module ActionSubscriber
       self.decoder.merge!(decoders)
     end
 
+    def async_publisher_error_handler=(handler)
+      if !handler.respond_to?(:call) || handler.arity != 1
+        fail "Error handler must respond to #call with an arity of 1"
+      end
+
+      @async_publisher_error_handler = handler
+    end
+
     def connection_string=(url)
       settings = ::ActionSubscriber::URI.parse_amqp_url(url)
       settings.each do |key, value|

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -3,6 +3,7 @@ module ActionSubscriber
     attr_accessor :allow_low_priority_methods,
                   :async_publisher,
                   :async_publisher_drop_messages_when_queue_full,
+                  :async_publisher_error_handler,
                   :async_publisher_max_queue_size,
                   :async_publisher_supervisor_interval,
                   :decoder,
@@ -24,10 +25,17 @@ module ActionSubscriber
                   :times_to_pop,
                   :virtual_host
 
+    DEFAULT_ERROR_HANDLER = lambda do |exception|
+      ::ActionSubscriber.logger.error exception.class
+      ::ActionSubscriber.logger.error exception.message
+      ::ActionSubscriber.logger.error exception.backtrace.join("\n") if exception.backtrace
+    end
+
     DEFAULTS = {
       :allow_low_priority_methods => false,
       :async_publisher => 'memory',
       :async_publisher_drop_messages_when_queue_full => false,
+      :async_publisher_error_handler => DEFAULT_ERROR_HANDLER,
       :async_publisher_max_queue_size => 1_000_000,
       :async_publisher_supervisor_interval => 200, # in milliseconds
       :default_exchange => 'events',

--- a/lib/action_subscriber/publisher/async/in_memory_adapter.rb
+++ b/lib/action_subscriber/publisher/async/in_memory_adapter.rb
@@ -65,6 +65,20 @@ module ActionSubscriber
             create_and_supervise_consumer!
           end
 
+          def error_handler
+            # This is currently not memoized because the configuration might change by some other
+            # gem loaded after action subscriber starts publishing. Because this code path only
+            # executes when something terrible happens, I think this trade-off is fine.
+            handler = ::ActionSubscriber.configuration.async_publisher_error_handler
+
+            if !handler.respond_to?(:call) || handler.arity != 1
+              logger.error "Error handler must respond to #call with an arity of 1"
+              return
+            end
+
+            handler
+          end
+
           def push(message)
             # Default of 1_000_000 messages.
             if queue.size > ::ActionSubscriber.configuration.async_publisher_max_queue_size
@@ -127,10 +141,8 @@ module ActionSubscriber
                   # Do not requeue the message because something else horrible happened.
                   @current_message = nil
 
-                  # Log the error.
-                  logger.info unknown_error.class
-                  logger.info unknown_error.message
-                  logger.info unknown_error.backtrace.join("\n")
+                  # Trigger error handler
+                  error_handler.call(unknown_error)
 
                   # TODO: Find a way to bubble this out of the thread for logging purposes.
                   # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.

--- a/lib/action_subscriber/publisher/async/in_memory_adapter.rb
+++ b/lib/action_subscriber/publisher/async/in_memory_adapter.rb
@@ -69,14 +69,7 @@ module ActionSubscriber
             # This is currently not memoized because the configuration might change by some other
             # gem loaded after action subscriber starts publishing. Because this code path only
             # executes when something terrible happens, I think this trade-off is fine.
-            handler = ::ActionSubscriber.configuration.async_publisher_error_handler
-
-            if !handler.respond_to?(:call) || handler.arity != 1
-              logger.error "Error handler must respond to #call with an arity of 1"
-              return
-            end
-
-            handler
+            ::ActionSubscriber.configuration.async_publisher_error_handler
           end
 
           def push(message)

--- a/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
@@ -92,6 +92,26 @@ describe ::ActionSubscriber::Publisher::Async::InMemoryAdapter do
       end
     end
 
+    describe "#error_handler" do
+      it "calls the error handler when something goes wrong" do
+        expect(subject).to receive(:error_handler)
+        subject.push(Object.new)
+        sleep 0.1 # Await results
+      end
+
+      context "when an invalid custom error handler is provided" do
+        let(:invalid_error_handler) { lambda {} }
+
+        before { ::ActionSubscriber.configuration.async_publisher_error_handler = invalid_error_handler }
+        after { ::ActionSubscriber.configuration.async_publisher_error_handler = ::ActionSubscriber::Configuration::DEFAULT_ERROR_HANDLER }
+
+        it "returns nil" do
+          expect(subject).to receive(:error_handler).and_return(nil)
+          expect(subject.error_handler).to be_nil
+        end
+      end
+    end
+
     describe "#push" do
       after { ::ActionSubscriber.configuration.async_publisher_max_queue_size = 1000 }
       after { ::ActionSubscriber.configuration.async_publisher_drop_messages_when_queue_full = false }

--- a/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/action_subscriber/publisher/async/in_memory_adapter_spec.rb
@@ -101,13 +101,10 @@ describe ::ActionSubscriber::Publisher::Async::InMemoryAdapter do
 
       context "when an invalid custom error handler is provided" do
         let(:invalid_error_handler) { lambda {} }
-
-        before { ::ActionSubscriber.configuration.async_publisher_error_handler = invalid_error_handler }
-        after { ::ActionSubscriber.configuration.async_publisher_error_handler = ::ActionSubscriber::Configuration::DEFAULT_ERROR_HANDLER }
+        let(:error_message) { "Error handler must respond to #call with an arity of 1" }
 
         it "returns nil" do
-          expect(subject).to receive(:error_handler).and_return(nil)
-          expect(subject.error_handler).to be_nil
+          expect { ::ActionSubscriber.configuration.async_publisher_error_handler = invalid_error_handler }.to raise_error(error_message)
         end
       end
     end


### PR DESCRIPTION
Adding an error handler to the async publisher will let anyone bubble errors wherever they need to go. By default, however, exceptions are logged and swallowed (not new behavior).

I think this PR is in an adequate state. What I'm unsure of is if this behavior should become a convention of action subscriber (set the default in the configuration), or leave this in the in-memory publisher so it's easier to extract into a publisher gem. You might think it's good enough as is, and that's cool too.

cc @mmmries @abrandoned @liveh2o @brianstien @localshred @brettallred 
