### PR TITLE
Require app after configuration has been loaded

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -3,6 +3,7 @@
 require 'active_support'
 require 'active_support/core_ext'
 require 'thor'
+require 'action_subscriber'
 
 module ActionSubscriber
   class CLI < ::Thor
@@ -23,12 +24,14 @@ module ActionSubscriber
     BABOUDESC
 
     def start
-      require options[:app]
-
       $0 = "Action Subscriber server #{object_id}"
       ::ActionSubscriber.logger.info "Loading configuration..."
 
       ::ActionSubscriber::Configuration.configure_from_yaml_and_cli(options)
+
+      ::ActionSubscriber.logger.info "Requiring app..."
+      require options[:app]
+
       ::ActionSubscriber.logger.info "Starting server..."
 
       case ::ActionSubscriber.configuration.mode

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$ACTION_SUBSCRIBER_SERVER_MODE = true
+
 require 'active_support'
 require 'active_support/core_ext'
 require 'thor'
@@ -30,7 +32,17 @@ module ActionSubscriber
       ::ActionSubscriber::Configuration.configure_from_yaml_and_cli(options)
 
       ::ActionSubscriber.logger.info "Requiring app..."
+
       require options[:app]
+
+      # We run these outside of lib/action_subscriber.rb because we need to load
+      # our railtie (Rails must be defined) before we can run our load hooks.
+      # When requiring action_subscriber as a client, these will be run
+      # automatically.
+      ::ActionSubscriber.logger.info "Running load hooks..."
+
+      require "action_subscriber/railtie" if defined?(Rails)
+      ::ActiveSupport.run_load_hooks(:action_subscriber, Base)
 
       ::ActionSubscriber.logger.info "Starting server..."
 

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -114,13 +114,17 @@ module ActionSubscriber
     alias_method :config, :configuration
   end
 
+  # Execution is delayed until after app loads when used with bin/action_subscriber
+  unless $ACTION_SUBSCRIBER_SERVER_MODE
+    ::ActiveSupport.run_load_hooks(:action_subscriber, Base)
+    require "action_subscriber/railtie" if defined?(Rails)
+  end
+
   # Initialize config object
   config
 
   # Intialize async publisher adapter
   ::ActionSubscriber::Publisher::Async.publisher_adapter
-
-  ::ActiveSupport.run_load_hooks(:action_subscriber, Base)
 
   ##
   # Private Implementation
@@ -144,10 +148,7 @@ module ActionSubscriber
     end
   end
   private_class_method :default_routes
-
 end
-
-require "action_subscriber/railtie" if defined?(Rails)
 
 at_exit do
   ::ActionSubscriber::Publisher::Async.publisher_adapter.shutdown!

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module ActionSubscriber
   class Configuration
     attr_accessor :allow_low_priority_methods,
@@ -57,7 +59,7 @@ module ActionSubscriber
       yaml_config = {}
       absolute_config_path = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
       if ::File.exists?(absolute_config_path)
-        yaml_config = ::YAML.load_file(absolute_config_path, :safe => true)[env]
+        yaml_config = ::YAML.load_file(absolute_config_path)[env]
       end
 
       ::ActionSubscriber::Configuration::DEFAULTS.each_pair do |key, value|


### PR DESCRIPTION
Because of how we're setting up routes to be drawn (on app load), we're
actually building the routes using a configuration that is using a
default config. However, when we infer routes, we're delaying this route
building to after the configuration has been loaded from CLI and yaml.

This means that #default_routes_for will not create *_low queues or set
real threadpool values despite your CLI or yaml config. If we require
the app after the ActionSubscriber gem has been configured, everything
works as expected.

Although this is a small code change and I don't imagine anyone having
problems, we are changing execution order, which is a pretty big design
change.

This is one of a few ways at fixing https://github.com/mxenabled/action_subscriber/issues/51

cc @mmmries @abrandoned @liveh2o @brianstien @localshred @brettallred