### PR TITLE
Delay ActionSubscriber.draw_routes execution until after config loads

### DIFF
--- a/spec/integration/inferred_routes_spec.rb
+++ b/spec/integration/inferred_routes_spec.rb
@@ -33,6 +33,13 @@ describe "A Subscriber With Inferred Routes", :integration => true do
 
   # This is the deprecated behavior we want to keep until version 2.0
   context "no explicit routes" do
+    before do
+      # TEST HACK: Bust any memoized routes.
+      ::ActionSubscriber.instance_variable_set(:@route_set, nil)
+      ::ActionSubscriber.instance_variable_set(:@draw_routes_block, nil)
+      ::ActionSubscriber.setup_queues!
+    end
+
     it "registers the routes and sets up the queues" do
       ::ActionSubscriber.auto_subscribe!
       ::ActionSubscriber::Publisher.publish("kyle.inference.yo", "YO", "events")


### PR DESCRIPTION
Because the app is loaded before ActionSubscriber configs, immediate
execution of the draw_routes block means routes will be built using the
default configs. This means threadpool settings and low priority queues
will not be included.

This is one of a few ways at fixing #51 

cc @mmmries @abrandoned @liveh2o @brianstien @localshred @brettallred