### PR TITLE
Multi-threadpool bugs

### DIFF
--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   else
     spec.add_dependency 'bunny', '>= 1.5.0'
   end
-  spec.add_dependency 'lifeguard'
+  spec.add_dependency 'lifeguard', '>= 0.0.9'
   spec.add_dependency 'middleware'
   spec.add_dependency 'thor'
 

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -81,6 +81,7 @@ module ActionSubscriber
         logger.info "    --    exchange: #{route.exchange}"
         logger.info "    --       queue: #{route.queue}"
         logger.info "    -- routing_key: #{route.routing_key}"
+        logger.info "    --  threadpool: #{route.threadpool.pool_size}"
       end
     end
   end

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -81,7 +81,7 @@ module ActionSubscriber
         logger.info "    --    exchange: #{route.exchange}"
         logger.info "    --       queue: #{route.queue}"
         logger.info "    -- routing_key: #{route.routing_key}"
-        logger.info "    --  threadpool: #{route.threadpool.pool_size}"
+        logger.info "    --  threadpool: #{route.threadpool.name}, pool_size: #{route.threadpool.pool_size}"
       end
     end
   end

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -96,8 +96,11 @@ module ActionSubscriber
       wait_loops = 0
       ::ActionSubscriber::Babou.stop_receving_messages!
 
-      while ::ActionSubscriber::Threadpool.pool.busy_size > 0 && wait_loops < ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
-        puts "waiting for threadpool to empty (#{::ActionSubscriber::Threadpool.pool.busy_size})"
+      while ::ActionSubscriber::Threadpool.busy? && wait_loops < ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
+        puts "waiting for threadpools to empty:"
+        ::ActionSubscriber::Threadpool.pools.each do |name, pool|
+          puts "  -- #{name} (remaining: #{pool.busy_size})" if pool.busy_size > 0
+        end
         Thread.pass
         wait_loops = wait_loops + 1
         sleep 1

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -17,6 +17,9 @@ module ActionSubscriber
         times_to_pop = [::ActionSubscriber::Threadpool.ready_size, ::ActionSubscriber.config.times_to_pop].min
         times_to_pop.times do
           queues.each do |route, queue|
+            # Handle busy checks on a per threadpool basis
+            next if route.threadpool.busy_size >= route.threadpool.pool_size
+
             delivery_info, properties, encoded_payload = queue.pop(route.queue_subscription_options)
             next unless encoded_payload # empty queue
             ::ActiveSupport::Notifications.instrument "popped_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -18,7 +18,7 @@ module ActionSubscriber
         times_to_pop.times do
           queues.each do |route, queue|
             # Handle busy checks on a per threadpool basis
-            next if route.threadpool.busy_size >= route.threadpool.pool_size
+            next if route.threadpool.busy?
 
             delivery_info, properties, encoded_payload = queue.pop(route.queue_subscription_options)
             next unless encoded_payload # empty queue

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -14,7 +14,7 @@ module ActionSubscriber
         times_to_pop.times do
           queues.each do |route,queue|
             # Handle busy checks on a per threadpool basis
-            next if route.threadpool.busy_size >= route.threadpool.pool_size
+            next if route.threadpool.busy?
 
             metadata, encoded_payload = queue.pop(route.queue_subscription_options)
             next unless encoded_payload

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -13,6 +13,9 @@ module ActionSubscriber
         times_to_pop = [::ActionSubscriber::Threadpool.ready_size, ::ActionSubscriber.config.times_to_pop].min
         times_to_pop.times do
           queues.each do |route,queue|
+            # Handle busy checks on a per threadpool basis
+            next if route.threadpool.busy_size >= route.threadpool.pool_size
+
             metadata, encoded_payload = queue.pop(route.queue_subscription_options)
             next unless encoded_payload
             ::ActiveSupport::Notifications.instrument "popped_event.action_subscriber", :payload_size => encoded_payload.bytesize, :queue => queue.name

--- a/lib/action_subscriber/threadpool.rb
+++ b/lib/action_subscriber/threadpool.rb
@@ -4,9 +4,7 @@ module ActionSubscriber
     # Class Methods
     #
     def self.busy?
-      pools.any? do |_pool_name, pool|
-        pool.pool_size == pool.busy_size
-      end
+      !ready?
     end
 
     def self.new_pool(name, pool_size = nil)
@@ -30,7 +28,9 @@ module ActionSubscriber
     end
 
     def self.ready?
-      !busy?
+      pools.any? do |_pool_name, pool|
+        pool.busy_size < pool.pool_size
+      end
     end
 
     def self.ready_size

--- a/lib/action_subscriber/threadpool.rb
+++ b/lib/action_subscriber/threadpool.rb
@@ -11,6 +11,7 @@ module ActionSubscriber
       fail ArgumentError, "#{name} already exists as a threadpool" if pools.key?(name)
       pool_size ||= ::ActionSubscriber.config.threadpool_size
       pools[name] = ::Lifeguard::InfiniteThreadpool.new(
+        :name => name,
         :pool_size => pool_size
       )
     end
@@ -22,15 +23,14 @@ module ActionSubscriber
     def self.pools
       @pools ||= {
         :default => ::Lifeguard::InfiniteThreadpool.new(
+          :name => :default,
           :pool_size => ::ActionSubscriber.config.threadpool_size
         )
       }
     end
 
     def self.ready?
-      pools.any? do |_pool_name, pool|
-        pool.busy_size < pool.pool_size
-      end
+      pools.any? { |_pool_name, pool| !pool.busy? }
     end
 
     def self.ready_size


### PR DESCRIPTION
This handles two different multi-threadpool bugs. They're small enough that I combined them together into one PR.

**1) Check any threadpool for room before skipping a round of pops (pop mode)**

In pop mode, we check to see if all pools have space before and won't check for new messages otherwise. This used to be fine but now that we allow multiple threadpools, we consider all threadpools full if any one of them is full, even though a larger pool may be empty.

To fix this, we flip the .busy? logic check to say, "we are .ready? for popping if any of the threadpools has room." We then need to add a guard clause around each queue when popping to skip if its threadpool is already full. This will ensure all threadpools are able to fill completely.

**2) Allow graceful shutdown check to work with multiple threadpools**

With this change we'll make sure all threadpools are empty before shutting down. It will only list threadpools that are not empty to avoid extra noise.

The new shutdown message looks like this:
```
waiting for threadpools to empty:
  -- default (remaining: 40)
  -- some_custom_pool (remaining: 2)
  -- yolo (remaining: 5)
threadpool empty. Shutting down
```

cc @mmmries @abrandoned @liveh2o @brianstien @localshred @quixoten @ztoolson @brettallred 