### PR TITLE
Alternative to global server require path, add a preload.rb

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -1,11 +1,7 @@
 #!/usr/bin/env ruby
 
-$ACTION_SUBSCRIBER_SERVER_MODE = true
-
-require 'active_support'
-require 'active_support/core_ext'
-require 'thor'
-require 'action_subscriber'
+require "action_subscriber/preload"
+require "thor"
 
 module ActionSubscriber
   class CLI < ::Thor
@@ -35,16 +31,10 @@ module ActionSubscriber
 
       require options[:app]
 
-      # We run these outside of lib/action_subscriber.rb because we need to load
-      # our railtie (Rails must be defined) before we can run our load hooks.
-      # When requiring action_subscriber as a client, these will be run
-      # automatically.
-      ::ActionSubscriber.logger.info "Running load hooks..."
-
-      require "action_subscriber/railtie" if defined?(Rails)
-      ::ActiveSupport.run_load_hooks(:action_subscriber, Base)
-
       ::ActionSubscriber.logger.info "Starting server..."
+
+      # Require action_subscriber if the application did not.
+      require "action_subscriber"
 
       case ::ActionSubscriber.configuration.mode
       when /pop/i then

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "action_subscriber/uri"
 
 module ActionSubscriber
   class Configuration

--- a/lib/action_subscriber/preload.rb
+++ b/lib/action_subscriber/preload.rb
@@ -1,0 +1,29 @@
+require "active_support"
+require "active_support/core_ext"
+require "middleware"
+
+require "action_subscriber/configuration"
+require "action_subscriber/logging"
+
+module ActionSubscriber
+  ##
+  # Public Class Methods
+  #
+  def self.logger
+    ::ActionSubscriber::Logging.logger
+  end
+
+  def self.configuration
+    @configuration ||= ::ActionSubscriber::Configuration.new
+  end
+
+  ##
+  # Class aliases
+  #
+  class << self
+    alias_method :config, :configuration
+  end
+
+  # Initialize config object
+  config
+end


### PR DESCRIPTION
This adds a preload (bootstrap) to give the bin stub just enough to configure itself before the app loads and runs the action subscriber railtie and load hooks. This solution should cover edge cases around rails eager loading causing subscribers to load before load hooks have been run under server mode.

Basically rails make loading things extremely difficult to follow. This should make (fingers crossed) everybody happy. This should handle loading with or without rails, with or without mixins, rails eager loading subscribers and loading action subscriber for client publishing.

cc @mmmries @abrandoned @liveh2o @brianstien @localshred @brettallred