### PR TITLE
Support durable exchanges

### DIFF
--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -26,7 +26,7 @@ module ActionSubscriber
 
     def setup_queue(route)
       channel = ::ActionSubscriber::RabbitConnection.subscriber_connection.create_channel
-      exchange = channel.topic(route.exchange)
+      exchange = channel.topic(route.exchange, :durable => route.durable)
       queue = channel.queue(route.queue, :durable => route.durable)
       queue.bind(exchange, :routing_key => route.routing_key)
       queue


### PR DESCRIPTION
Treat an exchange as durable if the route is marked as durable