### PR TITLE
Add support for per route middleware stacks

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -74,7 +74,7 @@ module ActionSubscriber
         logger.info "RECEIVED #{env.message_id} from #{env.queue}"
         threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key, :queue => env.queue do
-            ::ActionSubscriber.config.middleware.call(env)
+            env.middleware.call(env)
           end
         end
       end

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -33,6 +33,7 @@ module ActionSubscriber
               :message_id => nil,
               :routing_key => delivery_info.routing_key,
               :queue => queue.name,
+              :middleware => route.middleware
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             enqueue_env(route.threadpool, env)
@@ -57,6 +58,7 @@ module ActionSubscriber
               :message_id => properties.message_id,
               :routing_key => delivery_info.routing_key,
               :queue => queue.name,
+              :middleware => route.middleware
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             enqueue_env(route.threadpool, env)

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -29,6 +29,7 @@ module ActionSubscriber
               :message_id => metadata.message_id,
               :routing_key => metadata.routing_key,
               :queue => queue.name,
+              :middleware => route.middleware
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             enqueue_env(route.threadpool, env)
@@ -54,6 +55,7 @@ module ActionSubscriber
               :message_id => metadata.message_id,
               :routing_key => metadata.routing_key,
               :queue => queue.name,
+              :middleware => route.middleware
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             enqueue_env(route.threadpool, env)
@@ -73,7 +75,7 @@ module ActionSubscriber
         logger.info "RECEIVED #{env.message_id} from #{env.queue}"
         threadpool.async(env) do |env|
           ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key, :queue => env.queue do
-            ::ActionSubscriber.config.middleware.call(env)
+            env.middleware.call(env)
           end
         end
       end

--- a/lib/action_subscriber/middleware.rb
+++ b/lib/action_subscriber/middleware.rb
@@ -3,11 +3,12 @@ require "action_subscriber/middleware/env"
 require "action_subscriber/middleware/error_handler"
 require "action_subscriber/middleware/router"
 require "action_subscriber/middleware/runner"
+require "action_subscriber/middleware/stack"
 
 module ActionSubscriber
   module Middleware
     def self.initialize_stack
-      builder = ::Middleware::Builder.new(:runner_class => ::ActionSubscriber::Middleware::Runner)
+      builder = ::ActionSubscriber::Middleware::Stack.new(:runner_class => ::ActionSubscriber::Middleware::Runner)
 
       builder.use ErrorHandler
       builder.use Decoder

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -42,6 +42,15 @@ module ActionSubscriber
         @middleware = properties.fetch(:middleware) { ::ActionSubscriber.config.middleware.forked }
       end
 
+      #allow env to be get/set from outside, like rack middleware allows
+      def [](key)
+        instance_variable_get(:"@#{key}")
+      end
+
+      def []=(key, value)
+        instance_variable_set(:"@#{key}", value)
+      end
+
       def acknowledge
         acknowledge_multiple_messages = false
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -13,7 +13,8 @@ module ActionSubscriber
                   :message_id,
                   :routing_key,
                   :queue,
-                  :subscriber
+                  :subscriber,
+                  :middleware
 
       ##
       # @param subscriber [Class] the class that will handle this message
@@ -38,6 +39,7 @@ module ActionSubscriber
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber
+        @middleware = properties.fetch(:middleware) || ::ActionSubscriber.config.middleware
       end
 
       def acknowledge

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -39,7 +39,7 @@ module ActionSubscriber
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber
-        @middleware = properties.fetch(:middleware) || ::ActionSubscriber.config.middleware
+        @middleware = properties.fetch(:middleware)
       end
 
       def acknowledge

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -39,7 +39,7 @@ module ActionSubscriber
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber
-        @middleware = properties.fetch(:middleware)
+        @middleware = properties.fetch(:middleware) { ::ActionSubscriber.config.middleware.forked }
       end
 
       def acknowledge

--- a/lib/action_subscriber/middleware/stack.rb
+++ b/lib/action_subscriber/middleware/stack.rb
@@ -5,11 +5,7 @@ module ActionSubscriber
     class Stack < ::Middleware::Builder
       def forked
         forked_stack = self.class.new(:runner_class => @runner_class)
-
-        @stack.each do |middleware_args|
-          forked_stack.use(middleware_args.first)
-        end
-
+        forked_stack.instance_variable_set(:@stack, @stack.deep_dup)
         forked_stack
       end
     end

--- a/lib/action_subscriber/middleware/stack.rb
+++ b/lib/action_subscriber/middleware/stack.rb
@@ -3,14 +3,13 @@ require 'middleware/builder'
 module ActionSubscriber
   module Middleware
     class Stack < ::Middleware::Builder
-      def uses(*middlewares)
-        middlewares.each{ |middleware_args| use(*middleware_args) }
-      end
-
-      #fork is better method name but fork is defined on object
       def forked
         forked_stack = self.class.new(:runner_class => @runner_class)
-        forked_stack.uses(*@stack)
+
+        @stack.each do |middleware_args|
+          forked_stack.use(middleware_args.first)
+        end
+
         forked_stack
       end
     end

--- a/lib/action_subscriber/middleware/stack.rb
+++ b/lib/action_subscriber/middleware/stack.rb
@@ -1,0 +1,18 @@
+require 'middleware/builder'
+
+module ActionSubscriber
+  module Middleware
+    class Stack < ::Middleware::Builder
+      def uses(*middlewares)
+        middlewares.each{ |middleware_args| use(*middleware_args) }
+      end
+
+      #fork is better method name but fork is defined on object
+      def forked
+        forked_stack = self.class.new(:runner_class => @runner_class)
+        forked_stack.uses(*@stack)
+        forked_stack
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/middleware/stack.rb
+++ b/lib/action_subscriber/middleware/stack.rb
@@ -5,7 +5,7 @@ module ActionSubscriber
     class Stack < ::Middleware::Builder
       def forked
         forked_stack = self.class.new(:runner_class => @runner_class)
-        forked_stack.instance_variable_set(:@stack, @stack.deep_dup)
+        forked_stack.instance_variable_set(:@stack, @stack.dup)
         forked_stack
       end
     end

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -32,8 +32,9 @@ module ActionSubscriber
       { :manual_ack => acknowledgements? }
     end
 
-    def use(*middleware_args)
-      @middleware.use(*middleware_args)
-    end
+    delegate :use, :to => :middleware
+    delegate :insert, :to => :middleware
+    delegate :insert_after, :to => :middleware
+    delegate :insert_before, :to => :middleware
   end
 end

--- a/lib/action_subscriber/route.rb
+++ b/lib/action_subscriber/route.rb
@@ -2,13 +2,14 @@ module ActionSubscriber
   class Route
     attr_reader :acknowledgements,
                 :action,
-                :durable, 
+                :durable,
                 :exchange,
                 :prefetch,
                 :queue,
                 :routing_key,
                 :subscriber,
-                :threadpool
+                :threadpool,
+                :middleware
 
     def initialize(attributes)
       @acknowledgements = attributes.fetch(:acknowledgements)
@@ -20,6 +21,7 @@ module ActionSubscriber
       @routing_key = attributes.fetch(:routing_key)
       @subscriber = attributes.fetch(:subscriber)
       @threadpool = attributes.fetch(:threadpool) { ::ActionSubscriber::Threadpool.pool(:default) }
+      @middleware = attributes.fetch(:middleware) { ::ActionSubscriber.config.middleware.forked }
     end
 
     def acknowledgements?
@@ -28,6 +30,10 @@ module ActionSubscriber
 
     def queue_subscription_options
       { :manual_ack => acknowledgements? }
+    end
+
+    def use(*middleware_args)
+      @middleware.use(*middleware_args)
     end
   end
 end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -39,11 +39,13 @@ module ActionSubscriber
       route_settings[:subscriber].name.underscore.gsub(/_subscriber/, "").to_s
     end
 
-    def route(subscriber, action, options = {})
+    def route(subscriber, action, options = {}, &block)
       route_settings = DEFAULT_SETTINGS.merge(options).merge(:subscriber => subscriber, :action => action)
       route_settings[:routing_key] ||= default_routing_key_for(route_settings)
       route_settings[:queue] ||= default_queue_for(route_settings)
-      routes << Route.new(route_settings)
+      _route = Route.new(route_settings)
+      _route.instance_eval(&block) if block_given?
+      routes << _route
     end
 
     def routes

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -6,20 +6,11 @@ module ActionSubscriber
       router.routes
     end
 
-    # def self.stacks
-    #   @_stacks ||= {}
-    # end
-
-
     DEFAULT_SETTINGS = {
       :acknowledgements => false,
       :durable => false,
       :exchange => "events",
     }.freeze
-
-    def initialize
-      @stacks ||= {}
-    end
 
     def default_routing_key_for(route_settings)
       [
@@ -49,14 +40,18 @@ module ActionSubscriber
     end
 
     def stack(name, &block)
-      @stacks[name] ||= ::ActionSubscriber.config.middleware.forked.instance_eval(&block)
+      stacks[name] ||= ::ActionSubscriber.config.middleware.forked.instance_eval(&block)
+    end
+
+    def stacks
+      @stacks ||= {}
     end
 
     def route(subscriber, action, options = {}, &block)
       route_settings = DEFAULT_SETTINGS.merge(options).merge(:subscriber => subscriber, :action => action)
       route_settings[:routing_key] ||= default_routing_key_for(route_settings)
       route_settings[:queue] ||= default_queue_for(route_settings)
-      route_settings[:middleware] = @stacks[options[:stack]] if options.key?(:stack)
+      route_settings[:middleware] = stacks[options[:stack]] if options.key?(:stack)
       _route = Route.new(route_settings)
       _route.instance_eval(&block) if block_given?
       routes << _route

--- a/routing.md
+++ b/routing.md
@@ -38,9 +38,26 @@ The `route` method supports the following options:
 * `exchange` specify which exchange you expect messages to be published to (default `"events"`)
   * This is the equivalent of calling `exchange :actions` in your subscriber
 * `publisher` this will prefix your queue and routing key with the publishers name
-  * This is the equivalent of puting `publisher :foo` in your subscriber
+  * This is the equivalent of putting `publisher :foo` in your subscriber
 * `queue` specifies which queue you will subscribe to rather than letting ActionSubscriber infer it from the name of the subscriber and action
 * `routing_key` specifies the routing key that will be bound to your queue
+* `stack` Lets you use a custom middleware stack you already defined using the stack method
+
+## Middleware Stacks
+
+This give you the ability to build and apply a middleware stack on a per route basis.
+
+``` ruby
+::ActionSubscriber.draw_routes do
+  stack :resourceful do
+    use ParseResourcePayload
+    use LoadResource
+  end
+
+  default_routes_for ::UserSubscriber
+  route ::NotificationSubscriber, :created, :publisher => :newman, :exchange => :events, :stack => :resourceful
+end
+```
 
 <h3 id="footnotes">Footnotes</h3>
 

--- a/spec/lib/action_subscriber/middleware/env_spec.rb
+++ b/spec/lib/action_subscriber/middleware/env_spec.rb
@@ -25,6 +25,19 @@ describe ActionSubscriber::Middleware::Env do
   specify { expect(subject.routing_key).to eq(properties[:routing_key]) }
   specify { expect(subject.queue).to eq(properties[:queue]) }
 
+  describe "#[]" do
+    it "gets instance variable" do
+      expect(subject[:action]).to eq :created
+    end
+  end
+
+  describe "#[]=" do
+    it "sets instance variable" do
+      subject[:whatever] = :something
+      expect(subject[:whatever]).to eq :something
+    end
+  end
+
   describe "#acknowledge" do
     it "sends an acknowledgement to rabbitmq" do
       expect(channel).to receive(:ack).with(properties[:delivery_tag], false)

--- a/spec/lib/action_subscriber/middleware/stack_spec.rb
+++ b/spec/lib/action_subscriber/middleware/stack_spec.rb
@@ -1,0 +1,15 @@
+describe ActionSubscriber::Middleware::Stack do
+  subject { ::ActionSubscriber::Middleware.initialize_stack }
+
+  context "#forked" do
+    let(:forked_stack) { subject.forked }
+
+    it "duplicates the stack without modifying original" do
+      class A; end;
+      forked_stack.use(A)
+      expect(forked_stack.instance_variable_get(:@stack).object_id).to_not eq subject.instance_variable_get(:@stack).object_id
+      expect(forked_stack.instance_variable_get(:@stack).map(&:first)).to include(A)
+      expect(subject.instance_variable_get(:@stack).map(&:first)).to_not include(A)
+    end
+  end
+end

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -139,4 +139,28 @@ describe ActionSubscriber::Router do
     expect(routes.last.subscriber).to eq(SparkleSubscriber)
     expect(routes.last.queue).to eq("alice.tommy.sparkle.dim")
   end
+
+  it "can define a stack of middleware and use on a per route basis" do
+    class FakeMiddleware
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env
+      end
+    end
+
+    routes = described_class.draw_routes do
+      stack :fake_stack do
+        use FakeMiddleware
+      end
+
+      route FakeSubscriber, :foo, :stack => :fake_stack
+      route FakeSubscriber, :bar
+    end
+
+    expect(routes.first.middleware.instance_variable_get(:@stack).last.first).to eq(FakeMiddleware)
+    expect(routes.last.middleware.instance_variable_get(:@stack).last.first).to_not eq(FakeMiddleware)
+  end
 end


### PR DESCRIPTION
This adds support for setting up a middleware stack while defining routes, and using that middleware stack for a particular route.

As I began looking at ActionSubscriber to replace my existing async pubsub library, I came across the routing / middleware, which seems really cool. Problem is, middleware wouldn't really get me much in it's current form with what I'm looking to do as it's global. With this PR, each route can have it's own set of middleware, which is forked from `ActionSubscriber.config.middleware`. - I borrowed the idea from the Phoenix router and it's pipeline/plugs feature. http://www.phoenixframework.org/docs/routing

Use case example: parsing payload and to lookup the resource, and pass it along in it's loaded form. (while allowing non resourceful types of messages to be sent through other areas).

``` ruby
#assume you publish message in an ActiveRecord callback with the following format:
{
  :resource => self.attributes,
  :changes => self.changes,
  :resource_type => self.class.base_class.name
}

class HasChanges
  def initialize(app)
    @app = app
  end
  
  def call(env)
    env["changes"] = Changes.new(env["payload"]["changes"])
    @app.call(env)
  end
end

class HasResource
  def initialize(app)
    @app = app
  end
  
  def call(env)
    attributes = env["payload"]["resource"]
	model = env["payload"]["resource_type"].constantize
    env["resource"] = model.find(attributes["id"])
    @app.call(env)
  end
end

::ActionSubscriber.draw_routes do
  stack :resourceful do
    use HasChanges
    use HasResource
  end

  route ::Census::SurveysSubscriber, :updated, :durable => true, :exchange => :events, :stack => :resourceful
  route ::Census::SurveysSubscriber, :created, :durable => true, :exchange => :events, :stack => :resourceful
end
```

The main changes are that the middleware for the particular route gets passed in to the env, which will be executed rather than ActionSubscriber.config.middleware (but that's not a requirement if it can be looked up another way). Also the middleware stacks are now duplicated from the existing default middleware so that each route has it's own. The last large change is that I added hash accessors to env object so it behaves more like rack, which makes what you can do via the middlewares much more powerful. Tested and working with my local app except march hare/jruby.
