### PR TITLE
track if we have acknowledged or not a message that needs it and if n…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: ruby
 rvm:
- - 1.9
- - 2.0
- - 2.1
  - 2.2
- - jruby-1.7
+ - 2.3
  - jruby-9.0.4.0
  - jruby-head
  - rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
- - 2.2
- - 2.3
+ - 2.2.4
+ - 2.3.0
  - jruby-9.0.4.0
  - jruby-head
  - rbx-2

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -61,17 +61,67 @@ module ActionSubscriber
     end
 
     def _at_least_once_filter
+      processed_acknowledgement = false
       yield
-      acknowledge
+      processed_acknowledgement = acknowledge
     rescue => error
       ::ActionSubscriber::MessageRetry.redeliver_message_with_backoff(env)
-      acknowledge
+      processed_acknowledgement = acknowledge
       raise error
+    ensure
+      rejected_message = false
+      rejected_message = reject unless processed_acknowledgement
+
+      if !processed_acknowledgement && !rejected_message
+        $stdout << <<-UNREJECTABLE
+          CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
+
+          This is a exceptional state for RabbitMQ to enter and puts the current
+          Process in the position of "I can't get new work from RabbitMQ, but also
+          can't acknowledge or reject the work that I currently have" ... While rare
+          this state can happen.
+
+          Instead of continuing to try to process the message ActionSubscriber is
+          sending a Kill signal to the current running process to gracefully shutdown
+          so that the RabbitMQ server will purge any outstanding acknowledgements. If
+          you are running a process monitoring tool (like Upstart) the Subscriber
+          process will be restarted and be able to take on new work.
+
+          ** Running a process monitoring tool like Upstart is recommended for this reason **
+        UNREJECTABLE
+
+        Process.kill(:TERM, Process.pid)
+      end
     end
 
     def _at_most_once_filter
-      acknowledge
+      processed_acknowledgement = false
+      processed_acknowledgement = acknowledge
       yield
+    ensure
+      rejected_message = false
+      rejected_message = reject unless processed_acknowledgement
+
+      if !processed_acknowledgement && !rejected_message
+        $stdout << <<-UNREJECTABLE
+          CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
+
+          This is a exceptional state for RabbitMQ to enter and puts the current
+          Process in the position of "I can't get new work from RabbitMQ, but also
+          can't acknowledge or reject the work that I currently have" ... While rare
+          this state can happen.
+
+          Instead of continuing to try to process the message ActionSubscriber is
+          sending a Kill signal to the current running process to gracefully shutdown
+          so that the RabbitMQ server will purge any outstanding acknowledgements. If
+          you are running a process monitoring tool (like Upstart) the Subscriber
+          process will be restarted and be able to take on new work.
+
+          ** Running a process monitoring tool like Upstart is recommended for this reason **
+        UNREJECTABLE
+
+        Process.kill(:TERM, Process.pid)
+      end
     end
 
     def reject

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -73,6 +73,9 @@ module ActionSubscriber
       rejected_message = reject unless processed_acknowledgement
 
       if !processed_acknowledgement && !rejected_message
+        Process.kill(:TTIN, Process.pid)
+        Process.kill(:USR2, Process.pid)
+
         $stdout << <<-UNREJECTABLE
           CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
 
@@ -103,6 +106,9 @@ module ActionSubscriber
       rejected_message = reject unless processed_acknowledgement
 
       if !processed_acknowledgement && !rejected_message
+        Process.kill(:TTIN, Process.pid)
+        Process.kill(:USR2, Process.pid)
+
         $stdout << <<-UNREJECTABLE
           CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
 

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -79,7 +79,7 @@ module ActionSubscriber
         $stdout << <<-UNREJECTABLE
           CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
 
-          This is a exceptional state for RabbitMQ to enter and puts the current
+          This is a exceptional state for ActionSubscriber to enter and puts the current
           Process in the position of "I can't get new work from RabbitMQ, but also
           can't acknowledge or reject the work that I currently have" ... While rare
           this state can happen.
@@ -112,7 +112,7 @@ module ActionSubscriber
         $stdout << <<-UNREJECTABLE
           CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
 
-          This is a exceptional state for RabbitMQ to enter and puts the current
+          This is a exceptional state for ActionSubscriber to enter and puts the current
           Process in the position of "I can't get new work from RabbitMQ, but also
           can't acknowledge or reject the work that I currently have" ... While rare
           this state can happen.

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -43,11 +43,13 @@ module ActionSubscriber
       def acknowledge
         acknowledge_multiple_messages = false
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
+        true
       end
 
       def reject
         requeue_message = true
         @channel.reject(@delivery_tag, requeue_message)
+        true
       end
 
       def to_hash


### PR DESCRIPTION
…ecessary reset the process when neither can be done

Make sure we are either rejecting or acknowledging outstanding jobs from rabbitmq, in the case where we can do neither we need to "restart" the process as rabbitmq will stop sending messages down to the process

we wanted to make this state very understandable to any user that experiences it so we added a verbose output message and an attempted graceful process shutdown

@film42 @quixoten @mmmries @brettallred 