### PR TITLE
pass executor_factory to march_hare connections

### DIFF
--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -36,6 +36,9 @@ module ActionSubscriber
     def self.create_connection(settings)
       options = connection_options.merge(settings)
       if ::RUBY_PLATFORM == "java"
+        options[:executor_factory] = ::Proc.new do
+          ::MarchHare::ThreadPools.fixed_of_size(options[:threadpool_size])
+        end
         connection = ::MarchHare.connect(options)
       else
         connection = ::Bunny.new(options)


### PR DESCRIPTION
The `threadpool_size` option isn't used by `march_hare` like I thought it was. Passing in an explicit `executor_factory` works. I tested on my local machine by setting up a threadpool of 100 threads and a route with concurrency of 100 and watched it on visualvm.

It is actually using 100 threads now. :+1:

I think this should be a quick `3.0.1` release

/cc @abrandoned @brianbroderick