### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -101,6 +101,12 @@ module ActionSubscriber
     route_set.cancel_consumers!
   end
 
+  def self.wait_for_threadpools_to_finish_with_timeout(timeout)
+    puts "waiting for threadpools to empty (maximum wait of #{::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown}sec)"
+    ::ActionSubscriber::Threadpool.wait_to_finish_with_timeout(timeout)
+    route_set.wait_to_finish_with_timeout(timeout)
+  end
+
   # Execution is delayed until after app loads when used with bin/action_subscriber
   require "action_subscriber/railtie" if defined?(Rails)
   ::ActiveSupport.run_load_hooks(:action_subscriber, Base)

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -73,17 +73,27 @@ module ActionSubscriber
       wait_loops = 0
       ::ActionSubscriber::Babou.stop_receving_messages!
 
-      while ::ActionSubscriber::Threadpool.busy? && wait_loops < ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
-        puts "waiting for threadpools to empty:"
-        ::ActionSubscriber::Threadpool.pools.each do |name, pool|
-          puts "  -- #{name} (remaining: #{pool.busy_size})" if pool.busy_size > 0
-        end
-        Thread.pass
+      puts "waiting for threadpools to empty (maximum wait of #{::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown}sec)"
+      loop do
         wait_loops = wait_loops + 1
+        any_threadpools_busy = false
+        ::ActionSubscriber::Threadpool.pools.each do |name, pool|
+          next if pool.busy_size <= 0
+          puts "  -- #{name} (remaining: #{pool.busy_size})"
+          any_threadpools_busy = true
+        end
+        ::ActionSubscriber::RabbitConnection.connection_threadpools.each do |name, executor|
+          next if executor.get_active_count <= 0
+          puts "  -- Connection #{name} (remaining: #{executor.get_active_count})"
+          any_threadpools_busy = true
+        end
+        break unless any_threadpools_busy
+        break if wait_loops >= ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
+        Thread.pass
         sleep 1
       end
-
       puts "threadpool empty. Shutting down"
+      ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
     end
   end
 end

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -70,30 +70,12 @@ module ActionSubscriber
     def self.stop_server!
       # this method is called from within a TRAP context so we can't use the logger
       puts "Stopping server..."
-      wait_loops = 0
       ::ActionSubscriber::Babou.stop_receving_messages!
-
-      puts "waiting for threadpools to empty (maximum wait of #{::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown}sec)"
-      loop do
-        wait_loops = wait_loops + 1
-        any_threadpools_busy = false
-        ::ActionSubscriber::Threadpool.pools.each do |name, pool|
-          next if pool.busy_size <= 0
-          puts "  -- #{name} (remaining: #{pool.busy_size})"
-          any_threadpools_busy = true
-        end
-        ::ActionSubscriber::RabbitConnection.connection_threadpools.each do |name, executor|
-          next if executor.get_active_count <= 0
-          puts "  -- Connection #{name} (remaining: #{executor.get_active_count})"
-          any_threadpools_busy = true
-        end
-        break unless any_threadpools_busy
-        break if wait_loops >= ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
-        Thread.pass
-        sleep 1
-      end
-      puts "threadpool empty. Shutting down"
-      ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
+      ::ActionSubscriber.wait_for_threadpools_to_finish_with_timeout(::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown)
+      puts "Shutting down"
+      ::Thread.new do
+        ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
+      end.join
     end
   end
 end

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -73,6 +73,15 @@ module ActionSubscriber
         end
       end
 
+      def wait_to_finish_with_timeout(timeout)
+        puts <<-MSG
+          Currently bunny doesn't have any sort of a graceful shutdown or
+          the ability to check on the status of its ConsumerWorkPool objects.
+          For now we just wait for #{timeout}sec to let the worker pools drain.
+        MSG
+        sleep(timeout)
+      end
+
       private
 
       def enqueue_env(threadpool, env)

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -5,6 +5,16 @@ module ActionSubscriber
     SUBSCRIBER_CONNECTION_MUTEX = ::Mutex.new
     NETWORK_RECOVERY_INTERVAL = 1.freeze
 
+    def self.connection_threadpools
+      if ::RUBY_PLATFORM == "java"
+        subscriber_connections.each_with_object({}) do |(name, connection), hash|
+          hash[name] = connection.instance_variable_get("@executor")
+        end
+      else
+        [] # TODO can I get a hold of the thredpool that bunny uses?
+      end
+    end
+
     def self.setup_connection(name, settings)
       SUBSCRIBER_CONNECTION_MUTEX.synchronize do
         fail ArgumentError, "a #{name} connection already exists" if subscriber_connections[name]

--- a/lib/action_subscriber/threadpool.rb
+++ b/lib/action_subscriber/threadpool.rb
@@ -38,5 +38,25 @@ module ActionSubscriber
         total_ready + [0, pool.pool_size - pool.busy_size].max
       end
     end
+
+    def self.wait_to_finish_with_timeout(timeout)
+      wait_loops = 0
+      loop do
+        wait_loops = wait_loops + 1
+        any_threadpools_busy = false
+        pools.each do |name, pool|
+          next if pool.busy_size <= 0
+          puts "  -- #{name} (remaining: #{pool.busy_size})"
+          any_threadpools_busy = true
+        end
+        if !any_threadpools_busy
+          puts "  -- Lifeguard threadpools empty"
+          break
+        end
+        break if wait_loops >= timeout
+        Thread.pass
+        sleep 1
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix graceful shutdown for the `3.X` series.

Now that we are not using the lifeguard threadpools for `--mode=subscribe`, we need to wait on the threadpools that are managed by bunny/march_hare. Rather than have a conditional about which mode we are in I decided to just wait on the lifeguard threadpools and then wait on the march_hare pool.

Interestingly `bunny` implements its own [threapool](https://github.com/ruby-amqp/bunny/blob/9ee43e6fb7c57aa40721551d6f43468dd99d871a/lib/bunny/consumer_work_pool.rb) and it has no interface for checking the state of the pool, or any thread-safe way for me to gracefully shut down their threadpools. So as a poor fallback I've implemented it to cancel the consumers (stop receiving new messages) and then wait for the full timeout to give as much time as possible for the threads to empty out.

> Note: I was about to start fixing the output for the initial printing of subscriptions with their threadpools and the output when you send a `USR2` signal. But there is a big problem where ActionSubscriber has no idea whether it is in `--mode=subscribe` or `--mode=pop`. This makes it really hard to print the right information, and rather than fix that I think the time has come to drop support for `--mode=pop`. We might want to drop that support first before merging this so we can simplify the implementation.

/cc @abrandoned @brianstien @brettallred @brianbroderick @quixoten