### PR TITLE
Update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
- - 2.2.4
- - 2.3.0
- - jruby-9.0.4.0
- - jruby-9.1.5.0
+ - 2.2.6
+ - 2.3.3
+ - jruby-9.0.5.0
+ - jruby-9.1.7.0
  - jruby-head
 services:
  - rabbitmq

--- a/README.md
+++ b/README.md
@@ -155,3 +155,20 @@ easily test your public methods without dependence on data from Rabbit.  You can
 optionally pass data for your mock subscriber to consume if you wish.
 
 ``` subject { mock_subscriber(:header => "test_header", :payload => "payload") } ```
+
+Development
+===========
+
+If you want to work on `action_subscriber` you will need to have a rabbitmq instance running locally on port 5672 with a management plugin enabled on port 15672. Usually the easiest way to accomplish this is to use docker and run the command:
+
+```
+$ docker run --net=host --rm=true --hostname diagon --name rabbit rabbitmq:3.6.6-management
+```
+
+Now that rabbitmq is running you can clone this project and run:
+
+```
+$ cd action_subscriber
+$ bundle install
+$ bundle exec rspec
+```


### PR DESCRIPTION
While reviewing #79 I noticed that our test matrix in travis is slightly out of date. This PR updates to use the latest ruby 2.2.X, 2.3.X, jruby-9.0.X and jruby-9.1.X versions. I also added a README section to make it easier for people to get starting developing locally with `action_subscriber` by giving a single docker command that gets rabbit up and running.

/cc @film42 @andrew-lewin @abrandoned @ryanbjones 