### PR TITLE
using with_connection for connection mgmt

### DIFF
--- a/lib/action_subscriber/middleware/active_record/connection_management.rb
+++ b/lib/action_subscriber/middleware/active_record/connection_management.rb
@@ -39,7 +39,9 @@ module ActionSubscriber
 
         def call(env)
           def call(env)
-            @app.call(env)
+            ::ActiveRecord::Base.connection_pool.with_connection do
+              @app.call(env)
+            end
           end
 
           self.class.start_timed_task!

--- a/spec/lib/action_subscriber/middleware/active_record/connection_management_spec.rb
+++ b/spec/lib/action_subscriber/middleware/active_record/connection_management_spec.rb
@@ -3,7 +3,12 @@ require 'action_subscriber/middleware/active_record/connection_management'
 describe ActionSubscriber::Middleware::ActiveRecord::ConnectionManagement do
   include_context 'action subscriber middleware env'
 
-  before { allow(ActiveRecord::Base).to receive(:clear_active_connections!) }
+  before {
+    pool = double("pool")
+    allow(pool).to receive(:with_connection).and_yield
+    allow(ActiveRecord::Base).to receive(:clear_active_connections!)
+    allow(ActiveRecord::Base).to receive(:connection_pool).and_return(pool)
+  }
 
   subject { described_class.new(app) }
 


### PR DESCRIPTION
using the `with_connection` in the active record middleware so that connections get checked back in after a job runs (checkout verifies connections)

@brianstien @mmmries @film42 