### PR TITLE
Rbj/give warning on drawing routes

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -23,6 +23,9 @@ module ActionSubscriber
             logger.info "    -- routing_key: #{route.routing_key}"
             logger.info "    --    prefetch: #{route.prefetch}"
             logger.error "WARNING having a prefetch lower than your concurrency will prevent your subscriber from fully utilizing its threadpool" if route.prefetch < route.concurrency
+            if route.acknowledgements != subscriber.acknowledge_messages?
+              logger.error "WARNING subscriber has acknowledgements as #{subscriber.acknowledge_messages?} and route has acknowledgements as #{route.acknowledgements}"
+            end
           end
         end
       end

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -23,6 +23,9 @@ module ActionSubscriber
             logger.info "    --       queue: #{route.queue}"
             logger.info "    -- routing_key: #{route.routing_key}"
             logger.info "    --    prefetch: #{route.prefetch} per consumer (#{route.prefetch * route.concurrency} total)"
+            if route.acknowledgements != subscriber.acknowledge_messages?
+              logger.error "WARNING subscriber has acknowledgements as #{subscriber.acknowledge_messages?} and route has acknowledgements as #{route.acknowledgements}"
+            end
           end
         end
       end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -48,6 +48,20 @@ module ActionSubscriber
       end
     end
 
+    def local_application_name
+      @_local_application_name ||= begin
+        local_application_name = case
+                                 when ENV['APP_NAME'] then
+                                   ENV['APP_NAME'].to_s.dup
+                                 when defined?(::Rails) then
+                                   ::Rails.application.class.parent_name.dup
+                                 else
+                                   raise "Define an application name (ENV['APP_NAME'])"
+                                 end
+        local_application_name.downcase
+      end
+    end
+
     def resource_name(route_settings)
       route_settings[:subscriber].name.underscore.gsub(/_subscriber/, "").to_s
     end
@@ -64,18 +78,6 @@ module ActionSubscriber
       @routes ||= []
     end
 
-    def local_application_name
-      @_local_application_name ||= begin
-        local_application_name = case
-                                 when ENV['APP_NAME'] then
-                                   ENV['APP_NAME'].to_s.dup
-                                 when defined?(::Rails) then
-                                   ::Rails.application.class.parent_name.dup
-                                 else
-                                   raise "Define an application name (ENV['APP_NAME'])"
-                                 end
-        local_application_name.downcase
-      end
   private
 
     def discrepancy_in_acknowledgment_settings?(subscriber, options)

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -42,6 +42,7 @@ module ActionSubscriber
 
     def default_routes_for(subscriber, options = {})
       options = options.merge({:connection_name => @current_connection_name})
+      ::ActionSubscriber.logger.info "Discrepancy in message acknowledgments in #{subscriber}" if discrepancy_in_acknowledgment_settings?(subscriber, options)
       subscriber.routes(options).each do |route|
         routes << route
       end
@@ -52,6 +53,7 @@ module ActionSubscriber
     end
 
     def route(subscriber, action, options = {})
+      ::ActionSubscriber.logger.info "Discrepancy in message acknowledgments in #{subscriber}" if discrepancy_in_acknowledgment_settings?(subscriber, options)
       route_settings = DEFAULT_SETTINGS.merge(:connection_name => @current_connection_name).merge(options).merge(:subscriber => subscriber, :action => action)
       route_settings[:routing_key] ||= default_routing_key_for(route_settings)
       route_settings[:queue] ||= default_queue_for(route_settings)
@@ -74,6 +76,10 @@ module ActionSubscriber
                                  end
         local_application_name.downcase
       end
+  private
+
+    def discrepancy_in_acknowledgment_settings?(subscriber, options)
+      subscriber.acknowledge_messages? != !!options[:acknowledgements]
     end
   end
 end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -42,7 +42,6 @@ module ActionSubscriber
 
     def default_routes_for(subscriber, options = {})
       options = options.merge({:connection_name => @current_connection_name})
-      ::ActionSubscriber.logger.info "Discrepancy in message acknowledgments in #{subscriber}" if discrepancy_in_acknowledgment_settings?(subscriber, options)
       subscriber.routes(options).each do |route|
         routes << route
       end
@@ -67,7 +66,6 @@ module ActionSubscriber
     end
 
     def route(subscriber, action, options = {})
-      ::ActionSubscriber.logger.info "Discrepancy in message acknowledgments in #{subscriber}" if discrepancy_in_acknowledgment_settings?(subscriber, options)
       route_settings = DEFAULT_SETTINGS.merge(:connection_name => @current_connection_name).merge(options).merge(:subscriber => subscriber, :action => action)
       route_settings[:routing_key] ||= default_routing_key_for(route_settings)
       route_settings[:queue] ||= default_queue_for(route_settings)
@@ -76,12 +74,6 @@ module ActionSubscriber
 
     def routes
       @routes ||= []
-    end
-
-  private
-
-    def discrepancy_in_acknowledgment_settings?(subscriber, options)
-      subscriber.acknowledge_messages? != !!options[:acknowledgements]
     end
   end
 end

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -1,11 +1,5 @@
 describe ActionSubscriber::Router do
-  class FakeSubscriber < ActionSubscriber::Base; end
-  class AcknowledgeSubscriber < ActionSubscriber::Base
-    at_most_once!
-  end
-
-  let(:logger) { double(:logger, :info => nil) }
-  before { allow(::ActionSubscriber).to receive(:logger).and_return(logger) }
+  class FakeSubscriber; end
 
   it "can specify basic routes" do
     routes = described_class.draw_routes do
@@ -61,33 +55,6 @@ describe ActionSubscriber::Router do
     expect(routes.first.routing_key).to eq("fake.foo")
     expect(routes.first.subscriber).to eq(FakeSubscriber)
     expect(routes.first.queue).to eq("alice.fake.foo")
-
-  end
-
-  context "when the class specifies acknowledgements and route drawing does not" do
-    it "gives a warning if default_routes_for is used" do
-      expect(::ActionSubscriber).to receive(:logger).and_return(logger)
-
-      described_class.draw_routes do
-        default_routes_for ::AcknowledgeSubscriber
-      end
-    end
-
-    it "gives a warning if route is used" do
-      expect(::ActionSubscriber).to receive(:logger).and_return(logger)
-
-      described_class.draw_routes do
-        route ::AcknowledgeSubscriber, :foo
-      end
-    end
-
-    it "does not give a warning if they match" do
-      expect(::ActionSubscriber).to_not receive(:logger)
-
-      described_class.draw_routes do
-        route ::AcknowledgeSubscriber, :foo, :acknowledgements => true
-      end
-    end
   end
 
   it "can specify a queue is durable" do

--- a/spec/lib/action_subscriber/router_spec.rb
+++ b/spec/lib/action_subscriber/router_spec.rb
@@ -1,5 +1,11 @@
 describe ActionSubscriber::Router do
-  class FakeSubscriber; end
+  class FakeSubscriber < ActionSubscriber::Base; end
+  class AcknowledgeSubscriber < ActionSubscriber::Base
+    at_most_once!
+  end
+
+  let(:logger) { double(:logger, :info => nil) }
+  before { allow(::ActionSubscriber).to receive(:logger).and_return(logger) }
 
   it "can specify basic routes" do
     routes = described_class.draw_routes do
@@ -55,6 +61,33 @@ describe ActionSubscriber::Router do
     expect(routes.first.routing_key).to eq("fake.foo")
     expect(routes.first.subscriber).to eq(FakeSubscriber)
     expect(routes.first.queue).to eq("alice.fake.foo")
+
+  end
+
+  context "when the class specifies acknowledgements and route drawing does not" do
+    it "gives a warning if default_routes_for is used" do
+      expect(::ActionSubscriber).to receive(:logger).and_return(logger)
+
+      described_class.draw_routes do
+        default_routes_for ::AcknowledgeSubscriber
+      end
+    end
+
+    it "gives a warning if route is used" do
+      expect(::ActionSubscriber).to receive(:logger).and_return(logger)
+
+      described_class.draw_routes do
+        route ::AcknowledgeSubscriber, :foo
+      end
+    end
+
+    it "does not give a warning if they match" do
+      expect(::ActionSubscriber).to_not receive(:logger)
+
+      described_class.draw_routes do
+        route ::AcknowledgeSubscriber, :foo, :acknowledgements => true
+      end
+    end
   end
 
   it "can specify a queue is durable" do


### PR DESCRIPTION
From https://github.com/mxenabled/action_subscriber/issues/82

This will show the warning when drawing the routes....since routes are not drawn during specs it would only be seen on booting up the server, but it should make debugging at that point easier

@mmmries @mattnichols @abrandoned @film42 