### PR TITLE
add optional parameter for backoff schedule, fixes #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ Rabbit is told to expect message acknowledgements, but sending the acknowledgeme
 We send the acknowledgement right after calling your subscriber.
 If an error is raised your message will be retried on a sent back to rabbitmq and retried on an exponential backoff schedule.
 
+### retry
+
+A message can be sent to "retry" with `::ActionSubscriber::MessageRetry.redeliver_message_with_backoff` or the DSL method `retry` and optionally
+takes a "backoff schedule" which is a hash of backoff milliseconds for each retry, the default:
+
+```ruby
+  SCHEDULE = {
+    2  =>        100,
+    3  =>        500,
+    4  =>      2_500,
+    5  =>     12_500,
+    6  =>     62_500,
+    7  =>    312_500,
+    8  =>  1_562_500,
+    9  =>  7_812_500,
+    10 => 39_062_500,
+  }
+```
+
+when the schedule "returns" `nil` the message will not be retried
+
 Testing
 -----------------
 ActionSubscriber includes support for easy unit testing with RSpec.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ takes a "backoff schedule" which is a hash of backoff milliseconds for each retr
 
 when the schedule "returns" `nil` the message will not be retried
 
+> Warning: If you use `retry` you need to handle reject/acknowledge according how errors are handled; if an error is caught and the
+> ack/reject is already done then you may duplicate the message in `at_least_once!` mode
+
 Testing
 -----------------
 ActionSubscriber includes support for easy unit testing with RSpec.

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ Rabbit is told to expect message acknowledgements, but sending the acknowledgeme
 We send the acknowledgement right after calling your subscriber.
 If an error is raised your message will be retried on a sent back to rabbitmq and retried on an exponential backoff schedule.
 
-### retry
+### redeliver
 
-A message can be sent to "retry" with `::ActionSubscriber::MessageRetry.redeliver_message_with_backoff` or the DSL method `retry` and optionally
-takes a "backoff schedule" which is a hash of backoff milliseconds for each retry, the default:
+A message can be sent to "redeliver" with `::ActionSubscriber::MessageRetry.redeliver_message_with_backoff` or the DSL method `redeliver` and optionally
+takes a "backoff schedule" which is a hash of backoff milliseconds for each redeliver, the default:
 
 ```ruby
   SCHEDULE = {
@@ -184,7 +184,7 @@ takes a "backoff schedule" which is a hash of backoff milliseconds for each retr
 
 when the schedule "returns" `nil` the message will not be retried
 
-> Warning: If you use `retry` you need to handle reject/acknowledge according how errors are handled; if an error is caught and the
+> Warning: If you use `redeliver` you need to handle reject/acknowledge according how errors are handled; if an error is caught and the
 > ack/reject is already done then you may duplicate the message in `at_least_once!` mode
 
 Testing

--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ $ bundle exec action_subscriber start
 
 This will connect your subscribers to the rabbitmq broker and allow it to push messages down to your subscribers.
 
+### Around Filters
+"around" filters are responsible for running their associated actions by yielding, similar to how Rack middlewares work (and Rails around filters work)
+
+```ruby
+class UserSubscriber < ::ActionSubscriber::Base
+  around_filter :log_things
+
+  def created
+    # do something when a user is created
+  end
+
+  private
+
+  def log_things
+    puts "before I do some stuff"
+    yield
+    puts "I did some stuff"
+  end
+end
+```
+
+> Warning: an around filter will only be added once to the chain, duplicate around filters are not supported
+
 Configuration
 -----------------
 ActionSubscriber needs to know how to connect to your rabbit server to start getting messages.

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -60,7 +60,7 @@ module ActionSubscriber
       env.reject
     end
 
-    def retry(backoff_schedule = ::ActionSubscriber::MessageRetry::SCHEDULE)
+    def redeliver(backoff_schedule = ::ActionSubscriber::MessageRetry::SCHEDULE)
       ::ActionSubscriber::MessageRetry::redeliver_message_with_backoff(env, backoff_schedule)
     end
   end

--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -59,5 +59,9 @@ module ActionSubscriber
     def reject
       env.reject
     end
+
+    def retry(backoff_schedule = ::ActionSubscriber::MessageRetry::SCHEDULE)
+      ::ActionSubscriber::MessageRetry::redeliver_message_with_backoff(env, backoff_schedule)
+    end
   end
 end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -23,7 +23,8 @@ module ActionSubscriber
     end
 
     def around_filter(filter_method)
-      around_filters << filter_method
+      around_filters << filter_method unless around_filters.include?(filter_method)
+      around_filters
     end
 
     def around_filters

--- a/lib/action_subscriber/message_retry.rb
+++ b/lib/action_subscriber/message_retry.rb
@@ -12,9 +12,9 @@ module ActionSubscriber
       10 => 39_062_500,
     }.freeze
 
-    def self.redeliver_message_with_backoff(env)
+    def self.redeliver_message_with_backoff(env, backoff_schedule = SCHEDULE)
       next_attempt = get_last_attempt_number(env) + 1
-      ttl = SCHEDULE[next_attempt]
+      ttl = backoff_schedule[next_attempt]
       return unless ttl
       retry_queue_name = "#{env.queue}.retry_#{ttl}"
       with_exchange(env, ttl, retry_queue_name) do |exchange|

--- a/lib/action_subscriber/version.rb
+++ b/lib/action_subscriber/version.rb
@@ -1,3 +1,3 @@
 module ActionSubscriber
-  VERSION = "4.2.2"
+  VERSION = "4.2.3.pre"
 end

--- a/lib/action_subscriber/version.rb
+++ b/lib/action_subscriber/version.rb
@@ -1,3 +1,3 @@
 module ActionSubscriber
-  VERSION = "4.2.3.pre"
+  VERSION = "4.2.3.pre2"
 end

--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -1,6 +1,9 @@
 class InstaSubscriber < ActionSubscriber::Base
   around_filter :whisper
   around_filter :yell
+  around_filter :whisper
+  around_filter :whisper
+  around_filter :yell
 
   def first
     $messages << payload
@@ -28,6 +31,10 @@ describe "subscriber filters", :integration => true do
     end
   end
   let(:subscriber) { InstaSubscriber }
+
+  it "does not allow an around filter to be pushed on twice" do
+    expect(InstaSubscriber.around_filters).to eq([:whisper, :yell])
+  end
 
   it "runs multiple around filters" do
     $messages = []  #testing the order of things

--- a/spec/lib/action_subscriber/middleware/active_record/query_cache_spec.rb
+++ b/spec/lib/action_subscriber/middleware/active_record/query_cache_spec.rb
@@ -11,7 +11,8 @@ describe ActionSubscriber::Middleware::ActiveRecord::QueryCache do
     allow(connection).to receive(:enable_query_cache!)
 
     allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
-    allow(ActiveRecord::Base).to receive(:connection_id)
+    # Rails 5 "compat"
+    allow(ActiveRecord::Base).to receive(:connection_id) if ::ActiveRecord::Base.respond_to?(:connection_id)
   end
 
   subject { described_class.new(app) }


### PR DESCRIPTION
include `retry` method (private) and make the backoff schedule an optional parameter in the retry method

@mmmries @film42 