### PR TITLE
Fix Shutdown for Jruby

### DIFF
--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -40,11 +40,11 @@ module ActionSubscriber
       ::ActionSubscriber::Babou.start_subscribers
     end
   end
+end
 
-  [:INT, :QUIT, :TERM].each do |signal|
-    trap(signal) do
-      ::ActionSubscriber::Babou.stop_server!
-    end
+[:INT, :QUIT, :TERM].each do |signal|
+  trap(signal) do
+    ::ActionSubscriber::Babou.stop_server!
   end
 end
 

--- a/bin/action_subscriber
+++ b/bin/action_subscriber
@@ -41,16 +41,9 @@ module ActionSubscriber
     end
   end
 
-  if ::RUBY_PLATFORM == "java"
-    at_exit do
+  [:INT, :QUIT, :TERM].each do |signal|
+    trap(signal) do
       ::ActionSubscriber::Babou.stop_server!
-    end
-  else
-    [:INT, :QUIT, :TERM].each do |signal|
-      trap(signal) do
-        ::ActionSubscriber::Babou.stop_server!
-        exit 0
-      end
     end
   end
 end

--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -71,7 +71,7 @@ module ActionSubscriber
   def self.stop_subscribers!(timeout = nil)
     timeout ||= ::ActionSubscriber.configuration.seconds_to_wait_for_graceful_shutdown
     route_set.cancel_consumers!
-    puts "waiting for threadpools to empty (maximum wait of #{timeout}sec)"
+    logger.info "waiting for threadpools to empty (maximum wait of #{timeout}sec)"
     route_set.wait_to_finish_with_timeout(timeout)
   end
 

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -15,6 +15,11 @@ module ActionSubscriber
         sleep 1.0 #just hang around waiting for messages
         break if shutting_down?
       end
+
+      puts "Stopping subscribers..."
+      ::ActionSubscriber.stop_subscribers!
+      puts "Shutting down"
+      ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
     end
 
     def self.logger
@@ -32,14 +37,7 @@ module ActionSubscriber
     end
 
     def self.stop_server!
-      # this method is called from within a TRAP context so we can't use the logger
       @shutting_down = true
-      ::Thread.new do
-        puts "Stopping subscribers..."
-        ::ActionSubscriber.stop_subscribers!
-        puts "Shutting down"
-        ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
-      end.join
     end
   end
 end

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -16,10 +16,11 @@ module ActionSubscriber
         break if shutting_down?
       end
 
-      puts "Stopping subscribers..."
+      logger.info "Stopping subscribers..."
       ::ActionSubscriber.stop_subscribers!
-      puts "Shutting down"
+      logger.info "Shutting down"
       ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
+      logger.info "Shutdown complete"
     end
 
     def self.logger

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -84,11 +84,11 @@ module ActionSubscriber
           any_threadpools_busy = false
           ::ActionSubscriber::RabbitConnection.connection_threadpools.each do |name, executor|
             next if executor.get_active_count <= 0
-            puts "  -- Connection #{name} (active: #{executor.get_active_count}, queued: #{executor.get_queue.size})"
+            logger.info "  -- Connection #{name} (active: #{executor.get_active_count}, queued: #{executor.get_queue.size})"
             any_threadpools_busy = true
           end
           if !any_threadpools_busy
-            puts "Connection threadpools empty"
+            logger.info "Connection threadpools empty"
             break
           end
           break if wait_loops >= timeout


### PR DESCRIPTION
Probably not a good idea to rely on the `at_exit` signal to rely on shutdown events. Jruby can handle kill signals, so I'm not sure why this behavior needed to be different. It was written this way 2 years ago, and I don't think whatever the reason was is actually relevant anymore.

I actually ran into this because we were seeing protobuf nats errors because it relies on an `at_exit` shutdown signal to cleanup the client connection. Since this hijacks the `at_exit`, it was messing things up bigly.

cc @abrandoned @mmmries 