### PR TITLE
Remove extra thread in error handler - already in a threadpool + dont allow error handler to re-raise errors

### DIFF
--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -85,7 +85,13 @@ module ActionSubscriber
         'text/plain' => lambda { |payload| payload.dup }
       }
 
-      self.error_handler = lambda { |error, env_hash| raise }
+      self.error_handler = lambda do |error, env_hash|
+        logger = ::ActionSubscriber::Logging.logger
+
+        logger.error(error.message)
+        logger.error(error.class.to_s)
+        logger.error(error.backtrace.join("\n")) if error.try(:backtrace) && error.backtrace.is_a?(::Array)
+      end
 
       DEFAULTS.each_pair do |key, value|
         self.__send__("#{key}=", value)

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -8,26 +8,10 @@ module ActionSubscriber
       end
 
       def call(env)
-        job_mutex = ::Mutex.new
-        job_complete = ::ConditionVariable.new
-
-        job_mutex.synchronize do
-          ::Thread.new do
-            job_mutex.synchronize do
-              begin
-                @app.call(env)
-              rescue => error
-                logger.error "FAILED #{env.message_id}"
-                ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
-              ensure
-                job_complete.signal
-              end
-            end
-          end
-
-          # TODO we might want to pass a timeout to this wait so we can handle jobs that get frozen
-          job_complete.wait(job_mutex)
-        end
+        @app.call(env)
+      rescue => error
+        logger.error "FAILED #{env.message_id}"
+        ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
       end
     end
   end

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -11,7 +11,16 @@ module ActionSubscriber
         @app.call(env)
       rescue => error
         logger.error "FAILED #{env.message_id}"
-        ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
+
+        # There is more to this rescue than meets the eye. MarchHare's java library will rescue errors
+        # and attempt to close the channel with its default exception handler. To avoid this, we will
+        # stop errors right here. If you want to handle errors, you must do it in the error handler and
+        # it should not re-raise. As a bonus, not killing these threads is better for your runtime :).
+        begin
+          ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
+        rescue => error
+          logger.error "ActionSubscriber error handler raised error, but should never raise. Error: #{error}"
+        end
       end
     end
   end

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -43,4 +43,21 @@ describe ::ActionSubscriber::Configuration do
       expect(subject.virtual_host).to eq("vhost")
     end
   end
+
+  describe "error_handler" do
+    let(:logger) { ::ActionSubscriber::Logging.logger }
+
+    it "by default logs the error" do
+      expect(logger).to receive(:error).with("I'm confused")
+      expect(logger).to receive(:error).with("ArgumentError")
+      # Lame way of looking for the backtrace.
+      expect(logger).to receive(:error).with(/\.rb/)
+
+      begin
+        fail ::ArgumentError, "I'm confused"
+      rescue => error
+        subject.error_handler.call(error, {})
+      end
+    end
+  end
 end

--- a/spec/lib/action_subscriber/middleware/error_handler_spec.rb
+++ b/spec/lib/action_subscriber/middleware/error_handler_spec.rb
@@ -19,19 +19,4 @@ describe ActionSubscriber::Middleware::ErrorHandler do
       subject.call(env)
     end
   end
-
-  context "many concurrent threads" do
-    it "handles the race conditions without raising exceptions" do
-      no_op = lambda{ nil }
-      threads = 1.upto(100).map do
-        ::Thread.new do
-          ::Thread.current.abort_on_exception = true
-          100.times do
-            described_class.new(no_op).call(env)
-          end
-        end
-      end
-      threads.each(&:join)
-    end
-  end
 end


### PR DESCRIPTION
We're already off the main loop, so it's not protecting much. If it's trying to add extra inspection, it's probably not worth creating an extra thread for each message. 🔥 .

This also avoids letting the error handler re-raise errors, which seem to be the main cause for the java errors.

cc @mmmries @quixoten @liveh2o @brianstien @abrandoned 