### PR TITLE
make network recorvery interval configurable and default it to 1 second

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,26 @@ In an initializer, you can set the host and the port like this :
 Other configuration options include :
 
 * config.add_decoder - add a custom decoder for a custom content type
+* config.allow_low_priority_methods - Subscribe to `*_low` queues in addition to normal queues.
+* config.connection_reaping_interval - Connection reaping interval when using a project ActiveRecord
+* config.connection_reaping_timeout_interval - Connection reaping timeout interval when using a project ActiveRecord
 * config.default_exchange - set the default exchange that your queues will use, using the default RabbitMQ exchange is not recommended
 * config.error_handler - handle error like you want to handle them!
 * config.heartbeat - number of seconds between hearbeats (default 5) [see bunny documentation for more details](http://rubybunny.info/articles/connecting.html)
 * config.hosts - an array of hostnames in your cluster (ie `["rabbit1.myapp.com", "rabbit2.myapp.com"]`)
-* config.threadpool_size - set the number of threads availiable to action_subscriber
+* config.network_recovery_interval - reconnection interval for TCP connection failures (default 1)
+* config.password - RabbitMQ password (default "guest")
+* config.prefetch - number of messages to hold in the local queue in subscriber mode
+* config.seconds_to_wait_for_graceful_shutdown - time to wait before force stopping server after shutdown signal
+* config.threadpool_size - set the number of threads available to action_subscriber
 * config.timeout - how many seconds to allow rabbit to respond before timing out
 * config.tls - true/false whether to use TLS when connecting to the server
 * config.tls_ca_certificats - a list of ca certificates to use for verifying the servers TLS certificate
 * config.tls_cert - a client certificate to use during the TLS handshake
 * config.tls_key - a key to use during the TLS handshake
+* config.username - RabbitMQ username (default "guest")
 * config.verify_peer - whether to attempt to validate the server's TLS certificate
+* config.virtual_host - RabbitMQ virtual host (default "/")
 
 > Note: TLS is not handled identically in `bunny` and `march_hare`. The configuration options we provide are passed through as provided. For details on expected behavior please check the `bunny` or `march_hare` documentation based on whether you are running in MRI or jRuby.
 

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -12,6 +12,7 @@ module ActionSubscriber
                   :heartbeat,
                   :host,
                   :hosts,
+                  :network_recovery_interval,
                   :password,
                   :port,
                   :prefetch,
@@ -27,6 +28,7 @@ module ActionSubscriber
                   :virtual_host
 
     CONFIGURATION_MUTEX = ::Mutex.new
+    NETWORK_RECOVERY_INTERVAL = 1.freeze
 
     DEFAULTS = {
       :allow_low_priority_methods => false,
@@ -36,6 +38,7 @@ module ActionSubscriber
       :heartbeat => 5,
       :host => 'localhost',
       :hosts => [],
+      :network_recovery_interval => NETWORK_RECOVERY_INTERVAL,
       :password => "guest",
       :port => 5672,
       :prefetch => 2,

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -3,7 +3,6 @@ require 'thread'
 module ActionSubscriber
   module RabbitConnection
     SUBSCRIBER_CONNECTION_MUTEX = ::Mutex.new
-    NETWORK_RECOVERY_INTERVAL = 1.freeze
 
     def self.subscriber_connected?
       with_connection{|connection| connection.connected? }
@@ -45,7 +44,7 @@ module ActionSubscriber
         :continuation_timeout          => ::ActionSubscriber.configuration.timeout * 1_000.0, #convert sec to ms
         :heartbeat                     => ::ActionSubscriber.configuration.heartbeat,
         :hosts                         => ::ActionSubscriber.configuration.hosts,
-        :network_recovery_interval     => NETWORK_RECOVERY_INTERVAL,
+        :network_recovery_interval     => ::ActionSubscriber.configuration.network_recovery_interval,
         :pass                          => ::ActionSubscriber.configuration.password,
         :port                          => ::ActionSubscriber.configuration.port,
         :recover_from_connection_close => true,

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -4,6 +4,7 @@ describe ::ActionSubscriber::Configuration do
     specify { expect(subject.default_exchange).to eq("events") }
     specify { expect(subject.heartbeat).to eq(5) }
     specify { expect(subject.host).to eq("localhost") }
+    specify { expect(subject.network_recovery_interval).to eq(1) }
     specify { expect(subject.port).to eq(5672) }
     specify { expect(subject.prefetch).to eq(2) }
     specify { expect(subject.seconds_to_wait_for_graceful_shutdown).to eq(30) }


### PR DESCRIPTION
We want to make network recovery "longer" in our environment but keep the backward compat with the default being 1 second

(although if you use that you should be aware that it is a value that can have a race condition if it is too low)

https://github.com/ruby-amqp/march_hare/issues/83

This allows it to be configured by the configuration object/files

@film42 @quixoten 