### PR TITLE
add ack for multiple messages in at_most_once configuration

### DIFF
--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -9,10 +9,10 @@ module ActionSubscriber
       !!@_at_least_once
     end
 
-    def at_most_once!(multiple_offset = 1)
+    def at_most_once!(ack_every_n_messages = 1)
       @_acknowledge_messages = true
       @_at_most_once = true
-      @_multiple_offset = multiple_offset
+      @_ack_every_n_messages = ack_every_n_messages
     end
 
     def at_most_once?
@@ -55,8 +55,8 @@ module ActionSubscriber
       !!@_manual_acknowedgement
     end
 
-    def multiple_offset
-      @_multiple_offset
+    def ack_every_n_messages
+      @_ack_every_n_messages
     end
 
     def no_acknowledgement!
@@ -139,7 +139,7 @@ module ActionSubscriber
     def _run_action_at_most_once_multiple_with_filters(env, action)
       processed_acknowledgement = false
       rejected_message = false
-      if env.delivery_tag % multiple_offset == 0 # tags are monotonically increasing integers
+      if env.delivery_tag % ack_every_n_messages == 0 # tags are monotonically increasing integers
         processed_acknowledgement = env.acknowledge(true)
       else
         processed_acknowledgement = true # we are not acknowledging on this message and will wait for the offset to acknowledge
@@ -212,9 +212,9 @@ module ActionSubscriber
       case
       when at_least_once?
         _run_action_at_least_once_with_filters(env, action)
-      when at_most_once? && multiple_offset <= 1 # Acknowledging every single message
+      when at_most_once? && ack_every_n_messages <= 1 # Acknowledging every single message
         _run_action_at_most_once_with_filters(env, action)
-      when at_most_once? && multiple_offset > 1 # Acknowledging messages in offset groups (every 10 messages or whatever the offset is)
+      when at_most_once? && ack_every_n_messages > 1 # Acknowledging messages in offset groups (every 10 messages or whatever the offset is)
         _run_action_at_most_once_multiple_with_filters(env, action)
       else
         _run_action_with_filters(env, action)

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -9,9 +9,10 @@ module ActionSubscriber
       !!@_at_least_once
     end
 
-    def at_most_once!
+    def at_most_once!(multiple_offset = 1)
       @_acknowledge_messages = true
       @_at_most_once = true
+      @_multiple_offset = multiple_offset
     end
 
     def at_most_once?
@@ -52,6 +53,10 @@ module ActionSubscriber
 
     def manual_acknowledgement?
       !!@_manual_acknowedgement
+    end
+
+    def multiple_offset
+      @_multiple_offset
     end
 
     def no_acknowledgement!
@@ -131,6 +136,41 @@ module ActionSubscriber
       end
     end
 
+    def _run_action_at_most_once_multiple_with_filters(env, action)
+      processed_acknowledgement = false
+      rejected_message = false
+      if env.delivery_tag % multiple_offset == 0 # tags are monotonically increasing integers
+        processed_acknowledgement = env.acknowledge(true)
+      else
+        processed_acknowledgement = true # we are not acknowledging on this message and will wait for the offset to acknowledge
+      end
+
+      _run_action_with_filters(env, action)
+    ensure
+      rejected_message = env.reject if !processed_acknowledgement
+
+      if !rejected_message && !processed_acknowledgement
+        $stdout << <<-UNREJECTABLE
+          CANNOT ACKNOWLEDGE OR REJECT THE MESSAGE
+
+          This is a exceptional state for ActionSubscriber to enter and puts the current
+          Process in the position of "I can't get new work from RabbitMQ, but also
+          can't acknowledge or reject the work that I currently have" ... While rare
+          this state can happen.
+
+          Instead of continuing to try to process the message ActionSubscriber is
+          sending a Kill signal to the current running process to gracefully shutdown
+          so that the RabbitMQ server will purge any outstanding acknowledgements. If
+          you are running a process monitoring tool (like Upstart) the Subscriber
+          process will be restarted and be able to take on new work.
+
+          ** Running a process monitoring tool like Upstart is recommended for this reason **
+        UNREJECTABLE
+
+        Process.kill(:TERM, Process.pid)
+      end
+    end
+
     def _run_action_at_least_once_with_filters(env, action)
       processed_acknowledgement = false
       rejected_message = false
@@ -172,8 +212,10 @@ module ActionSubscriber
       case
       when at_least_once?
         _run_action_at_least_once_with_filters(env, action)
-      when at_most_once?
+      when at_most_once? && multiple_offset <= 1 # Acknowledging every single message
         _run_action_at_most_once_with_filters(env, action)
+      when at_most_once? && multiple_offset > 1 # Acknowledging messages in offset groups (every 10 messages or whatever the offset is)
+        _run_action_at_most_once_multiple_with_filters(env, action)
       else
         _run_action_with_filters(env, action)
       end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -56,7 +56,7 @@ module ActionSubscriber
     end
 
     def ack_every_n_messages
-      @_ack_every_n_messages
+      @_ack_every_n_messages || 1
     end
 
     def no_acknowledgement!

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -7,6 +7,7 @@ module ActionSubscriber
 
       attr_reader :action,
                   :content_type,
+                  :delivery_tag,
                   :encoded_payload,
                   :exchange,
                   :headers,
@@ -40,9 +41,9 @@ module ActionSubscriber
         @subscriber = subscriber
       end
 
-      def acknowledge
+      def acknowledge(acknowledge_multiple_messages = nil)
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
-        acknowledge_multiple_messages = false
+        acknowledge_multiple_messages = false if acknowledge_multiple_messages.nil?
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
         true
       end

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -41,9 +41,8 @@ module ActionSubscriber
         @subscriber = subscriber
       end
 
-      def acknowledge(acknowledge_multiple_messages = nil)
+      def acknowledge(acknowledge_multiple_messages = false)
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
-        acknowledge_multiple_messages = false if acknowledge_multiple_messages.nil?
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
         true
       end

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -23,7 +23,7 @@ module ActionSubscriber
           logger.info "    --       queue: #{route.queue}"
           logger.info "    -- routing_key: #{route.routing_key}"
           logger.info "    --    prefetch: #{route.prefetch}"
-          if route.prefetch < subscriber.ack_every_n_messages
+          if subscriber.at_most_once? && (route.prefetch < subscriber.ack_every_n_messages || subscriber.ack_every_n_messages <= 0)
             # https://www.rabbitmq.com/blog/2011/09/24/sizing-your-rabbits/
             logger.error "ERROR Subscriber has ack_every_n_messages as #{subscriber.ack_every_n_messages} and route has prefetch as #{route.prefetch}"
             fail "prefetch < ack_every_n_messages, deadlock will occur"

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -23,6 +23,11 @@ module ActionSubscriber
           logger.info "    --       queue: #{route.queue}"
           logger.info "    -- routing_key: #{route.routing_key}"
           logger.info "    --    prefetch: #{route.prefetch}"
+          if route.prefetch < subscriber.ack_every_n_messages
+            # https://www.rabbitmq.com/blog/2011/09/24/sizing-your-rabbits/
+            logger.error "ERROR Subscriber has ack_every_n_messages as #{subscriber.ack_every_n_messages} and route has prefetch as #{route.prefetch}"
+            fail "prefetch < ack_every_n_messages, deadlock will occur"
+          end
           if route.acknowledgements != subscriber.acknowledge_messages?
             logger.error "WARNING subscriber has acknowledgements as #{subscriber.acknowledge_messages?} and route has acknowledgements as #{route.acknowledgements}"
           end

--- a/lib/action_subscriber/version.rb
+++ b/lib/action_subscriber/version.rb
@@ -1,3 +1,3 @@
 module ActionSubscriber
-  VERSION = "5.0.2"
+  VERSION = "5.0.3.pre1"
 end


### PR DESCRIPTION
We are finding that ack-ing every messages in `at_most_once!` mode is slowing down consumption; this is an example interface for allowing multiple messages to be ack'ed at once during `at_most_once!` mode .... certainly some questions around what happens when a batch of messages do not get ack'd together and how it can potentially starve the prefetch (also being sure that the prefetch is aligned correctly to this number so it doesn't starve ... ie a prefetch of 5 with an offset batch of 10 would deadlock)

@film42 @quixoten @brianstien  