### PR TITLE
Abrandoned/attempt to reject bad middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This also allows the broker to send messages as quickly as it wants down to your
 
 ### manual_acknowledgement!
 
-This mode leaves it up to the subscriber to handle acknowledging or rejecting messages. In your subscriber you can just call <code>acknowledge</code> or <code>reject</code>.
+This mode leaves it up to the subscriber to handle acknowledging or rejecting messages. In your subscriber you can just call <code>acknowledge</code>, <code>reject</code>, or <code>nack</code>.
 
 ### at_most_once!
 
@@ -171,6 +171,11 @@ Rabbit is told to expect message acknowledgements, but sending the acknowledgeme
 Rabbit is told to expect message acknowledgements, but sending the acknowledgement is left up to ActionSubscriber.
 We send the acknowledgement right after calling your subscriber.
 If an error is raised your message will be retried on a sent back to rabbitmq and retried on an exponential backoff schedule.
+
+### safe_nack
+If you turn on acknowledgements and a message is not acknowledged by your code manually or using one of the filters above the `ErrorHandler` middleware
+which wraps the entire block with call <code>nack</code> this is a last resort so the connection does not get backed up in cases of unexpected or
+unhandled errors.
 
 ### redeliver
 

--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "active_publisher", "~> 0.1.5"
   spec.add_development_dependency "activerecord", ">= 3.2"
   spec.add_development_dependency "bundler", ">= 1.6"
+  spec.add_development_dependency "pry-coolline"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "rabbitmq_http_api_client", "~> 1.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -44,6 +44,7 @@ module ActionSubscriber
               :message_id => properties.message_id,
               :routing_key => delivery_info.routing_key,
               :queue => queue.name,
+              :uses_acknowledgements => route.acknowledgements?,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             run_env(env, threadpool)

--- a/lib/action_subscriber/march_hare/subscriber.rb
+++ b/lib/action_subscriber/march_hare/subscriber.rb
@@ -42,6 +42,7 @@ module ActionSubscriber
               :message_id => metadata.message_id,
               :routing_key => metadata.routing_key,
               :queue => queue.name,
+              :uses_acknowledgements => route.acknowledgements?,
             }
             env = ::ActionSubscriber::Middleware::Env.new(route.subscriber, encoded_payload, properties)
             run_env(env, threadpool)

--- a/lib/action_subscriber/middleware.rb
+++ b/lib/action_subscriber/middleware.rb
@@ -9,8 +9,8 @@ module ActionSubscriber
     def self.initialize_stack
       builder = ::Middleware::Builder.new(:runner_class => ::ActionSubscriber::Middleware::Runner)
 
-      builder.use ErrorHandler
-      builder.use Decoder
+      builder.use ::ActionSubscriber::Middleware::ErrorHandler
+      builder.use ::ActionSubscriber::Middleware::Decoder
 
       builder
     end

--- a/lib/action_subscriber/middleware.rb
+++ b/lib/action_subscriber/middleware.rb
@@ -1,3 +1,4 @@
+require "action_subscriber/logging"
 require "action_subscriber/middleware/decoder"
 require "action_subscriber/middleware/env"
 require "action_subscriber/middleware/error_handler"
@@ -6,8 +7,23 @@ require "action_subscriber/middleware/runner"
 
 module ActionSubscriber
   module Middleware
+
+    class Builder < ::Middleware::Builder
+      include ::ActionSubscriber::Logging
+
+      def print_middleware_stack
+        logger.info "Middlewares ["
+
+        stack.each do |middleware|
+          logger.info "#{middleware}"
+        end
+
+        logger.info "]"
+      end
+    end
+
     def self.initialize_stack
-      builder = ::Middleware::Builder.new(:runner_class => ::ActionSubscriber::Middleware::Runner)
+      builder = ::ActionSubscriber::Middleware::Builder.new(:runner_class => ::ActionSubscriber::Middleware::Runner)
 
       builder.use ::ActionSubscriber::Middleware::ErrorHandler
       builder.use ::ActionSubscriber::Middleware::Decoder

--- a/lib/action_subscriber/middleware/active_record/connection_management.rb
+++ b/lib/action_subscriber/middleware/active_record/connection_management.rb
@@ -38,7 +38,7 @@ module ActionSubscriber
         end
 
         def call(env)
-          def call(env)
+          def call(env) # redefines so it only gets called once
             ::ActiveRecord::Base.connection_pool.with_connection do
               @app.call(env)
             end

--- a/lib/action_subscriber/middleware/decoder.rb
+++ b/lib/action_subscriber/middleware/decoder.rb
@@ -18,7 +18,7 @@ module ActionSubscriber
       private
 
       def decoder
-        ActionSubscriber.config.decoder[env.content_type]
+        ::ActionSubscriber.config.decoder[env.content_type]
       end
 
       def decoder?

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -36,11 +36,12 @@ module ActionSubscriber
         @has_been_acked = false
         @has_been_nacked = false
         @has_been_rejected = false
-        @headers = properties.fetch(:headers) || {}
-        @message_id = properties.fetch(:message_id) || ::SecureRandom.hex(3)
+        @headers = properties.fetch(:headers, {})
+        @message_id = properties.fetch(:message_id, ::SecureRandom.hex(3))
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber
+        @uses_acknowledgements = properties.fetch(:uses_acknowledgements, false)
       end
 
       def acknowledge
@@ -69,15 +70,15 @@ module ActionSubscriber
       end
 
       def safe_acknowledge
-        acknowledge if @channel && !has_used_delivery_tag?
+        acknowledge if uses_acknowledgements? && @channel && !has_used_delivery_tag?
       end
 
       def safe_nack
-        nack if @channel && !has_used_delivery_tag?
+        nack if uses_acknowledgements? && @channel && !has_used_delivery_tag?
       end
 
       def safe_reject
-        reject if @channel && !has_used_delivery_tag?
+        reject if uses_acknowledgements? && @channel && !has_used_delivery_tag?
       end
 
       def to_hash
@@ -97,6 +98,9 @@ module ActionSubscriber
         @has_been_acked || @has_been_nacked || @has_been_rejected
       end
 
+      def uses_acknowledgements?
+        @uses_acknowledgements
+      end
     end
   end
 end

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -9,8 +9,9 @@ module ActionSubscriber
 
       def call(env)
         @app.call(env)
-      rescue => error
-        logger.error "FAILED #{env.message_id}"
+      rescue Exception => error # make sure we capture any exception from the top of the hierarchy
+        logger.error { "FAILED #{env.message_id}" }
+        env.safe_nack # Make sure we attempt to `nack` a message that did not get processed if something fails
 
         # There is more to this rescue than meets the eye. MarchHare's java library will rescue errors
         # and attempt to close the channel with its default exception handler. To avoid this, we will
@@ -18,8 +19,8 @@ module ActionSubscriber
         # it should not re-raise. As a bonus, not killing these threads is better for your runtime :).
         begin
           ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
-        rescue => error
-          logger.error "ActionSubscriber error handler raised error, but should never raise. Error: #{error}"
+        rescue Exception => inner_error
+          logger.error { "ActionSubscriber error handler raised error, but should never raise. Error: #{inner_error}" }
         end
       end
     end

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -11,7 +11,6 @@ module ActionSubscriber
         @app.call(env)
       rescue Exception => error # make sure we capture any exception from the top of the hierarchy
         logger.error { "FAILED #{env.message_id}" }
-        env.safe_nack # Make sure we attempt to `nack` a message that did not get processed if something fails
 
         # There is more to this rescue than meets the eye. MarchHare's java library will rescue errors
         # and attempt to close the channel with its default exception handler. To avoid this, we will
@@ -22,6 +21,8 @@ module ActionSubscriber
         rescue Exception => inner_error
           logger.error { "ActionSubscriber error handler raised error, but should never raise. Error: #{inner_error}" }
         end
+      ensure
+        env.safe_nack # Make sure we attempt to `nack` a message that did not get processed if something fails
       end
     end
   end

--- a/lib/action_subscriber/middleware/router.rb
+++ b/lib/action_subscriber/middleware/router.rb
@@ -1,6 +1,7 @@
 module ActionSubscriber
   module Middleware
     class Router
+      INSTRUMENT_KEY = "process_event.action_subscriber".freeze
       include ::ActionSubscriber::Logging
 
       def initialize(app)
@@ -8,11 +9,27 @@ module ActionSubscriber
       end
 
       def call(env)
-        logger.info { "START #{env.message_id} #{env.subscriber}##{env.action}" }
-        ::ActiveSupport::Notifications.instrument "process_event.action_subscriber", :subscriber => env.subscriber.to_s, :routing_key => env.routing_key, :queue => env.queue do
-          env.subscriber.run_action_with_filters(env, env.action)
+        action = env.action
+        message_id = env.message_id
+        queue = env.queue
+        routing_key = env.routing_key
+        subscriber = env.subscriber
+
+        logger.info { "START #{message_id} #{subscriber}##{action}" }
+
+        instrument_call(subscriber, routing_key, queue) do
+          subscriber.run_action_with_filters(env, action)
         end
-        logger.info { "FINISHED #{env.message_id}" }
+
+        logger.info { "FINISHED #{message_id}" }
+      end
+
+    private
+
+      def instrument_call(subscriber, routing_key, queue)
+        ::ActiveSupport::Notifications.instrument INSTRUMENT_KEY, :subscriber => subscriber.to_s, :routing_key => routing_key, :queue => queue do
+          yield
+        end
       end
     end
   end

--- a/lib/action_subscriber/railtie.rb
+++ b/lib/action_subscriber/railtie.rb
@@ -6,8 +6,8 @@ module ActionSubscriber
       require "action_subscriber/middleware/active_record/connection_management"
       require "action_subscriber/middleware/active_record/query_cache"
 
-      ::ActionSubscriber.config.middleware.use ::ActionSubscriber::Middleware::ActiveRecord::ConnectionManagement
-      ::ActionSubscriber.config.middleware.use ::ActionSubscriber::Middleware::ActiveRecord::QueryCache
+      ::ActionSubscriber.config.middleware.insert_after ::ActionSubscriber::Middleware::Decoder, ::ActionSubscriber::Middleware::ActiveRecord::ConnectionManagement
+      ::ActionSubscriber.config.middleware.insert_after ::ActionSubscriber::Middleware::ActiveRecord::ConnectionManagement, ::ActionSubscriber::Middleware::ActiveRecord::QueryCache
     end
   end
 end

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -12,7 +12,12 @@ module ActionSubscriber
       @routes = routes
     end
 
+    def print_middleware_stack
+      ::ActionSubscriber.config.middleware.print_middleware_stack
+    end
+
     def print_subscriptions
+      print_middleware_stack
       routes.group_by(&:subscriber).each do |subscriber, routes|
         logger.info subscriber.name
         routes.each do |route|

--- a/lib/action_subscriber/rspec.rb
+++ b/lib/action_subscriber/rspec.rb
@@ -26,6 +26,7 @@ module ActionSubscriber
       :message_id => "MSG-123",
       :routing_key => "amigo.user.created",
       :queue => "test.amigo.user.created",
+      :uses_acknoledgements => false,
     }.freeze
 
     # Create a new subscriber instance. Available options are:

--- a/lib/action_subscriber/rspec.rb
+++ b/lib/action_subscriber/rspec.rb
@@ -7,6 +7,10 @@ module ActionSubscriber
         true
       end
 
+      def nack(delivery_tag, acknowledge_multiple, requeue_message)
+        true
+      end
+
       def reject(delivery_tag, requeue_message)
         true
       end

--- a/lib/action_subscriber/version.rb
+++ b/lib/action_subscriber/version.rb
@@ -1,3 +1,3 @@
 module ActionSubscriber
-  VERSION = "5.0.3"
+  VERSION = "5.1.0.pre"
 end

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -22,7 +22,7 @@ describe "Manual Message Acknowledgment", :integration => true do
   end
   let(:subscriber) { BaconSubscriber }
 
-  it "retries rejected messages and stops retrying acknowledged messages" do
+  it "retries rejected/nacked messages and stops retrying acknowledged messages" do
     ::ActionSubscriber.start_subscribers!
     ::ActivePublisher.publish("bacon.served", "BACON!", "events")
 

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -3,8 +3,10 @@ class BaconSubscriber < ActionSubscriber::Base
 
   def served
     $messages << "#{payload}::#{$messages.size}"
-    if $messages.size > 2
+    if $messages.size > 3
       acknowledge
+    elsif $messages.size > 2
+      nack
     else
       reject
     end
@@ -24,8 +26,8 @@ describe "Manual Message Acknowledgment", :integration => true do
     ::ActionSubscriber.start_subscribers!
     ::ActivePublisher.publish("bacon.served", "BACON!", "events")
 
-    verify_expectation_within(2.0) do
-      expect($messages).to eq(Set.new(["BACON!::0", "BACON!::1", "BACON!::2"]))
+    verify_expectation_within(2.5) do
+      expect($messages).to eq(Set.new(["BACON!::0", "BACON!::1", "BACON!::2", "BACON!::3"]))
     end
   end
 end

--- a/spec/lib/action_subscriber/middleware/error_handler_spec.rb
+++ b/spec/lib/action_subscriber/middleware/error_handler_spec.rb
@@ -7,14 +7,32 @@ describe ActionSubscriber::Middleware::ErrorHandler do
 
   it_behaves_like 'an action subscriber middleware'
 
-  let(:error) { ::RuntimeError.new("Boom!") }
+  let(:load_error) { ::LoadError.new("Boom!") }
+  let(:runtime_error) { ::RuntimeError.new("Boom!") }
 
   context "when an exception occurs" do
-    before { allow(app).to receive(:call).and_raise(error) }
+    context "LoadError" do
+      before { allow(app).to receive(:call).and_raise(load_error) }
+      it "calls the exception handler with a LoadError" do
+        handler = ::ActionSubscriber.configuration.error_handler
+        expect(handler).to receive(:call).with(load_error, env.to_h)
 
-    it "calls the exception handler" do
-      handler = ::ActionSubscriber.configuration.error_handler
-      expect(handler).to receive(:call).with(error, env.to_h)
+        subject.call(env)
+      end
+    end
+
+    context "RuntimError" do
+      before { allow(app).to receive(:call).and_raise(runtime_error) }
+      it "calls the exception handler with a RuntimeError" do
+        handler = ::ActionSubscriber.configuration.error_handler
+        expect(handler).to receive(:call).with(runtime_error, env.to_h)
+
+        subject.call(env)
+      end
+    end
+
+    it "calls safe_nack after execution" do
+      expect(env).to receive(:safe_nack)
 
       subject.call(env)
     end


### PR DESCRIPTION
We have seen scenarios where the message is delivered but an error occurs before it is executed and the error handling in the subscriber never accounts for the message that is now "lost"

this adds a `nack` method (which is the recommended way of doing message rerun) and also `safe_` versions of all of the methods that need the channel and the delivery tag (the safe methods can be run multiple times and will only use the delivery_tag once)

This allows us to put in the error handler middleware a mechanism to make sure we `nack` a message that errors out

I also changed the `rescue` to rescue from `Exception` as that is the highest in the Ruby hierarchy so we can catch all errors/exceptions

Also makes sure we set the connection swapping and management middlewares with `insert_after` because they should be specifically included after the `Decoder` middleware

@film42 @mmmries @brianstien @quixoten @liveh2o 