### PR TITLE
Safer safe methods

### DIFF
--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -52,6 +52,11 @@ module ActionSubscriber
         true
       end
 
+      def channel_open?
+        return false unless @channel
+        @channel.open?
+      end
+
       def nack
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
         nack_multiple_messages = false
@@ -70,15 +75,15 @@ module ActionSubscriber
       end
 
       def safe_acknowledge
-        acknowledge if uses_acknowledgements? && @channel && !has_used_delivery_tag?
+        acknowledge if uses_acknowledgements? && channel_open? && !has_used_delivery_tag?
       end
 
       def safe_nack
-        nack if uses_acknowledgements? && @channel && !has_used_delivery_tag?
+        nack if uses_acknowledgements? && channel_open? && !has_used_delivery_tag?
       end
 
       def safe_reject
-        reject if uses_acknowledgements? && @channel && !has_used_delivery_tag?
+        reject if uses_acknowledgements? && channel_open? && !has_used_delivery_tag?
       end
 
       def to_hash

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -46,6 +46,7 @@ module ActionSubscriber
 
       def acknowledge
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
+        return if @has_been_acked
         acknowledge_multiple_messages = false
         @has_been_acked = true
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
@@ -59,6 +60,7 @@ module ActionSubscriber
 
       def nack
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
+        return if @has_been_nacked
         nack_multiple_messages = false
         requeue_message = true
         @has_been_nacked = true
@@ -68,6 +70,7 @@ module ActionSubscriber
 
       def reject
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
+        return if @has_been_rejected
         requeue_message = true
         @has_been_rejected = true
         @channel.reject(@delivery_tag, requeue_message)

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -46,7 +46,7 @@ module ActionSubscriber
 
       def acknowledge
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
-        return if @has_been_acked
+        return true if @has_been_acked
         acknowledge_multiple_messages = false
         @has_been_acked = true
         @channel.ack(@delivery_tag, acknowledge_multiple_messages)
@@ -60,7 +60,7 @@ module ActionSubscriber
 
       def nack
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
-        return if @has_been_nacked
+        return true if @has_been_nacked
         nack_multiple_messages = false
         requeue_message = true
         @has_been_nacked = true
@@ -70,7 +70,7 @@ module ActionSubscriber
 
       def reject
         fail ::RuntimeError, "you can't acknowledge messages under the polling API" unless @channel
-        return if @has_been_rejected
+        return true if @has_been_rejected
         requeue_message = true
         @has_been_rejected = true
         @channel.reject(@delivery_tag, requeue_message)


### PR DESCRIPTION
This changes the `safe_*` methods on `env` to check to make sure the channel is open before attempting to call ack, nack, etc. Additionally, I added an extra rescue block around `safe_nack` in the error handler middleware to prevent any failed rabbit connection operation from escaping the middleware. I'm sure there's a more elegant way to capture this, but for now I'm logging it since a failure to nack will still allow rabbit to retry the message.

I also added protection to prevent a single message from acking, nacking or rejecting more than once. I found in testing that doing so might allow the current message to succeed, but a second or third message might explode with one of the following strange errors:

```
Java::ComRabbitmqClient::AlreadyClosedException:
       channel is already closed due to channel error; protocol method: #method<channel.close>(reply-code=406, reply-text=PRECONDITION_FAILED - unknown delivery tag 4, class-id=60, method-id=80)
```

and this one (less often, but still happens):

```
Failure/Error: Unable to find com.rabbitmq.client.impl.AMQChannel.wrap(com/rabbitmq/client/impl/AMQChannel.java to read failed line
```

With ack, nack and rejected returning if they've already been called once before, the above errors do not happen. 

NOTE: To get the errors to happen I edited the manual ack spec to ack, nack and reject multiple times.

Btw, if you're thinking, "wait, what if I get an error that I rescue and I want to retry nacking again or something? the way we return would prevent me from recovering from retrying in the event of an error!" don't worry. Right now we don't have a way to swap out the channel within the message's env, so if something :boom: s, the message will need to be retried. We might want to look into adding support here later, but with the current implementation, this is really a non-issue for now.

cc @brianstien @abrandoned @liveh2o @quixoten 