### PR TITLE
we shouldnt need to create new channels on errors

### DIFF
--- a/lib/action_subscriber/message_retry.rb
+++ b/lib/action_subscriber/message_retry.rb
@@ -46,7 +46,7 @@ module ActionSubscriber
     end
 
     def self.with_exchange(env, ttl, retry_queue_name)
-      channel = RabbitConnection.with_connection{|connection| connection.create_channel}
+      channel = env.channel
       begin
         channel.confirm_select
         # an empty string is the default exchange [see bunny docs](http://rubybunny.info/articles/exchanges.html#default_exchange)
@@ -54,8 +54,6 @@ module ActionSubscriber
         queue = channel.queue(retry_queue_name, :arguments => {"x-dead-letter-exchange" => "", "x-message-ttl" => ttl, "x-dead-letter-routing-key" => env.queue})
         yield(exchange)
         channel.wait_for_confirms
-      ensure
-        channel.close rescue nil
       end
     end
   end

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -6,6 +6,7 @@ module ActionSubscriber
       attr_accessor :payload
 
       attr_reader :action,
+                  :channel,
                   :content_type,
                   :encoded_payload,
                   :exchange,


### PR DESCRIPTION
Currently redelivers are creating new channels for every call.  If we are getting ~5k errors a sec that's 1-1 for channel creation.  Instead, this reuses the existent channel to publish backoff messages.