### PR TITLE
rebuilds subscriptions on consumer_cancel_notify

### DIFF
--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "pry-coolline"
   spec.add_development_dependency "pry-nav"
-  spec.add_development_dependency "rabbitmq_http_api_client", "~> 1.2.0"
+  spec.add_development_dependency "rabbitmq_http_api_client", "~> 1.9.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"
 end

--- a/spec/integration/consumer_cancel_notify_spec.rb
+++ b/spec/integration/consumer_cancel_notify_spec.rb
@@ -1,0 +1,34 @@
+require "rabbitmq/http/client"
+
+class ZombieSubscriber < ActionSubscriber::Base
+  def groan
+    $messages << payload
+  end
+end
+
+describe "Rebuilds subscription after receiving consumer_cancel_notify", :integration => true, :slow => true do
+ let(:draw_routes) do
+   ::ActionSubscriber.draw_routes do
+     default_routes_for ZombieSubscriber
+   end
+ end
+ let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
+ let(:subscriber) { ZombieSubscriber }
+
+ it "continues to receive messages following consumer_cancel_notify message" do
+   ::ActionSubscriber::start_subscribers!
+   ::ActivePublisher.publish("zombie.groan", "uuunngg", "events")
+   
+   delete_queue!
+   sleep 5.0
+
+   ::ActivePublisher.publish("zombie.groan", "meeuuhhh", "events")
+   verify_expectation_within(5.0) do
+     expect($messages).to eq(Set.new(["uuunngg", "meeuuhhh"]))
+   end
+ end
+
+ def delete_queue!
+  http_client.delete_queue("/","alice.zombie.groan")
+ end
+end


### PR DESCRIPTION
One of RabbitMQ's extensions to AMQP is to have a broker:
> send to the client a basic.cancel in the case of ... unexpected consumer cancellations.

[The documentation](https://www.rabbitmq.com/consumer-cancel.html) for the extension describes these "unexpected consumer cancellations" as:
> events, such as the queue being deleted, or in a clustered scenario, the node on which the queue is located failing, will cause the consumption to be cancelled, but the client channel will not be informed, which is frequently unhelpful.

The default behavior for both bunny and march_hare is to present support for this capability when connecting to RabbitMQ. Therefore, by default ActionSubscribers will receive basic.cancel signals when on the the scenarios described above occurs. Currently, when that happens, the ActionSubscriber will not attempt to resume consumption but rather will sit idle because no further messages will be sent from the broker on that channel. This change attempts to rebuild the subscription so consumption of messages will resume after the basic.cancel signal is received.


