### PR TITLE
More instrumentation around ack, nack, and reject operations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,3 +51,15 @@ def verify_expectation_within(number_of_seconds, check_every = 0.02)
     end
   end
 end
+
+# This helper method allows us to verify a subscription is cleaned up after every test.
+# Its arguments are the instrumentation key and a proc that contains the work to be
+# performed for each notification.
+def with_instrumentation_subscription(instrumentation_key, work)
+  subscription = ::ActiveSupport::Notifications.subscribe(instrumentation_key) do |name, start, finish, id, payload|
+    work.call(name, start, finish, id, payload)
+  end
+  yield
+ensure
+  ::ActiveSupport::Notifications.unsubscribe(subscription)
+end


### PR DESCRIPTION
It occurred to me that we aren't measuring the time it takes to complete an ACK, NACK, or REJECT operation in action subscriber. We do this in active publisher and found it useful to detect if rabbitmq is pushing back on publishers to keep up. Does this happen on the subscriber side? I'm not sure, but this PR is me trying to find out.

I'm concerned about performance, but, since we're measuring a round-trip TCP message, I think the overhead will be negligible. Once I have the harness code in place, I can report back what kind of extra overhead we're talking about in practice.

cc @abrandoned @liveh2o @hugh-j @ETetzlaff 