### PR TITLE
set message id properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
  - 2.3.3
  - jruby-9.0.5.0
  - jruby-9.1.7.0
+ - jruby-9.1.12.0
  - jruby-head
 services:
  - rabbitmq

--- a/lib/action_subscriber/middleware/env.rb
+++ b/lib/action_subscriber/middleware/env.rb
@@ -38,7 +38,7 @@ module ActionSubscriber
         @has_been_nacked = false
         @has_been_rejected = false
         @headers = properties.fetch(:headers, {})
-        @message_id = properties.fetch(:message_id, ::SecureRandom.hex(3))
+        @message_id = properties[:message_id].presence || ::SecureRandom.hex(3)
         @queue = properties.fetch(:queue)
         @routing_key = properties.fetch(:routing_key)
         @subscriber = subscriber


### PR DESCRIPTION
@film42 

I noticed we have a lot of weird spaces in the logs and came across this.  We aren't setting message_id appropriately as `properties.fetch(:message_id)` returns empty string and doesn't hit the SecureRandom.hex(3)

Alternatively, I think tying the delivery_tag of the message delivery and prepending that with the channel id/number might be a better solution for logging but this at least fixes a small symptom right now.