### PR TITLE
Add :if and :unless conditions to around_filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 os:
   linux
 dist:
-  trusty
+  xenial
 rvm:
  - 2.2.6
  - 2.3.3
@@ -10,6 +10,9 @@ rvm:
  - jruby-9.1.7.0
  - jruby-9.1.12.0
  - jruby-head
+addons:
+  packages:
+    - rabbitmq-server
 services:
  - rabbitmq
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+os:
+  linux
+dist:
+  trusty
 rvm:
  - 2.2.6
  - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ rvm:
  - jruby-9.1.12.0
  - jruby-head
 addons:
-  packages:
-    - rabbitmq-server
+  apt:
+    packages:
+      - rabbitmq-server
 services:
  - rabbitmq
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 os:
   linux
 dist:
-  xenial
+  trusty
 rvm:
  - 2.2.6
  - 2.3.3
@@ -10,10 +10,6 @@ rvm:
  - jruby-9.1.7.0
  - jruby-9.1.12.0
  - jruby-head
-addons:
-  apt:
-    packages:
-      - rabbitmq-server
 services:
  - rabbitmq
 sudo: false

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -1,56 +1,54 @@
-require "pry"
-
-class Filter
-  attr_accessor :method
-  attr_accessor :included_actions
-  attr_accessor :excluded_actions
-
-  def initialize(method, options)
-    @method = method
-    @included_actions = @excluded_actions = []
-    parse_options(options)
-  end
-
-  def matches(action)
-    unless included_actions.empty?
-      return included_actions.include?(action)
-    end
-
-    unless excluded_actions.empty?
-      return false if excluded_actions.include?(action)
-    end
-
-    true
-  end
-
-private
-
-  def matches_excluded?(action)
-    return false if excluded_actions.empty?
-
-    return excluded_actions.include?(action)
-  end
-
-  def matches_included?(action)
-    return true if included_actions.empty?
-
-    return included_actions.include?(action)
-  end
-
-  def no_conditions
-    included_actions.empty? && excluded_actions.empty?
-  end
-
-  def parse_options(options)
-    return unless options
-
-    @included_actions  = options.fetch(:if, [])
-    @excluded_actions = options.fetch(:unless, [])
-  end
-end
 
 module ActionSubscriber
   module DSL
+    class Filter
+      attr_accessor :method
+      attr_accessor :included_actions
+      attr_accessor :excluded_actions
+
+      def initialize(method, options)
+        @method = method
+        @included_actions = @excluded_actions = []
+        parse_options(options)
+      end
+
+      def matches(action)
+        unless included_actions.empty?
+          return included_actions.include?(action)
+        end
+
+        unless excluded_actions.empty?
+          return false if excluded_actions.include?(action)
+        end
+
+        true
+      end
+
+    private
+
+      def matches_excluded?(action)
+        return false if excluded_actions.empty?
+
+        return excluded_actions.include?(action)
+      end
+
+      def matches_included?(action)
+        return true if included_actions.empty?
+
+        return included_actions.include?(action)
+      end
+
+      def no_conditions
+        included_actions.empty? && excluded_actions.empty?
+      end
+
+      def parse_options(options)
+        return unless options
+
+        @included_actions  = options.fetch(:if, [])
+        @excluded_actions = options.fetch(:unless, [])
+      end
+    end
     def at_least_once!
       @_acknowledge_messages = true
       @_at_least_once = true

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -56,7 +56,7 @@ module ActionSubscriber
     end
 
     def around_filter(filter_method, options = nil)
-      filter = ::DSL::Filter.new(filter_method, options)
+      filter = Filter.new(filter_method, options)
       conditionally_add_filter!(filter)
       around_filters
     end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -1,12 +1,12 @@
 module ActionSubscriber
   module DSL
     class Filter
-      attr_accessor :action
+      attr_accessor :callback_method
       attr_accessor :included_actions
       attr_accessor :excluded_actions
 
-      def initialize(action, options)
-        @action = action
+      def initialize(callback_method, options)
+        @callback_method = callback_method
         @included_actions = @excluded_actions = []
         parse_options(options)
       end
@@ -55,14 +55,14 @@ module ActionSubscriber
       !!@_acknowledge_messages
     end
 
-    def around_filter(filter_method, options = nil)
-      filter = Filter.new(filter_method, options)
+    def around_filter(callback_method, options = nil)
+      filter = Filter.new(callback_method, options)
       conditionally_add_filter!(filter)
       around_filters
     end
 
     def conditionally_add_filter!(filter)
-      around_filters << filter unless around_filters.any? { |f| f.action == filter.action }
+      around_filters << filter unless around_filters.any? { |f| f.callback_method == filter.callback_method }
     end
 
     def around_filters
@@ -134,7 +134,7 @@ module ActionSubscriber
 
       first_proc = around_filters.reverse.reduce(final_block) do |block, filter|
         if filter.matches(action)
-          Proc.new { subscriber_instance.send(filter.method, &block) } if filter.matches(action)
+          Proc.new { subscriber_instance.send(filter.callback_method, &block) } if filter.matches(action)
         else
           block
         end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -134,7 +134,7 @@ module ActionSubscriber
 
       first_proc = around_filters.reverse.reduce(final_block) do |block, filter|
         if filter.matches(action)
-          Proc.new { subscriber_instance.send(filter.callback_method, &block) } if filter.matches(action)
+          Proc.new { subscriber_instance.send(filter.callback_method, &block) }
         else
           block
         end

--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -33,7 +33,7 @@ describe "subscriber filters", :integration => true do
   let(:subscriber) { InstaSubscriber }
 
   it "does not allow an around filter to be pushed on twice" do
-    expect(InstaSubscriber.around_filters).to eq([:whisper, :yell])
+    expect(InstaSubscriber.around_filters.map(&:method)).to eq([:whisper, :yell])
   end
 
   it "runs multiple around filters" do
@@ -43,6 +43,85 @@ describe "subscriber filters", :integration => true do
 
     verify_expectation_within(1.0) do
       expect($messages).to eq [:whisper_before, :yell_before, "hEY Guyz!", :yell_after, :whisper_after]
+    end
+  end
+end
+
+class OptionsSubscriber < ActionSubscriber::Base
+  around_filter :whisper, :if => [:primero, :segundo, :private_action]
+  around_filter :yell, :if => [:primero]
+  around_filter :gossip, :unless => [:private_action]
+
+  def primero
+    $messages << payload
+  end
+
+  def segundo
+    $messages << payload
+  end
+
+  def private_action
+    $messages << payload
+  end
+
+  private
+
+  def whisper
+    $messages << :whisper_before
+    yield
+    $messages << :whisper_after
+  end
+
+  def yell
+    $messages << :yell_before
+    yield
+    $messages << :yell_after
+  end
+
+  def gossip
+    $messages << :gossip_before
+    yield
+    $messages << :gossip_after
+  end
+end
+
+describe "subscriber filters with conditions", :integration => true do
+  let(:draw_routes) do
+    ::ActionSubscriber.draw_routes do
+      default_routes_for OptionsSubscriber
+    end
+  end
+  let(:subscriber) { OptionsSubscriber }
+
+  context "honors conditions" do
+    it "runs yell" do
+      $messages = []
+      ::ActionSubscriber.start_subscribers!
+      ::ActivePublisher.publish("options.primero", "Howdy!", "events")
+
+      verify_expectation_within(1.0) do
+        expect($messages).to eq [:whisper_before, :yell_before, :gossip_before, "Howdy!", :gossip_after, :yell_after, :whisper_after]
+      end
+    end
+
+    it "doesn't yell" do
+      $messages = []
+      ::ActionSubscriber.start_subscribers!
+      ::ActivePublisher.publish("options.segundo", "Howdy!", "events")
+
+      verify_expectation_within(1.0) do
+        expect($messages).to eq [:whisper_before, :gossip_before, "Howdy!", :gossip_after, :whisper_after]
+      end
+    end
+
+    it "doesn't gossip" do
+      $messages = []
+      ::ActionSubscriber.start_subscribers!
+      ::ActivePublisher.publish("options.private_action", "Howdy!", "events")
+
+      verify_expectation_within(1.0) do
+        expect($messages).to eq [:whisper_before, "Howdy!", :whisper_after]
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow things like this:

  `around_filter :yell, :if => [:this_action]`

or

  `around_filter :yell, :unless => [:quiet_action]`

but, it won't handle:

  `around_filter :broken, :if => [:this_action, :that_action], :unless
  => [:this_action]`

That won't work.  

Just don't try it!  

It **will** fail silently!