### PR TITLE
Add connection_{un}blocked.action_subscriber notifications

### DIFF
--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -33,12 +33,18 @@ module ActionSubscriber
         connection.on_blocked do |reason|
           on_blocked(reason)
         end
+        connection.on_unblocked do
+          on_unblocked
+        end
         connection
       else
         connection = ::Bunny.new(options)
         connection.start
         connection.on_blocked do |blocked_message|
           on_blocked(blocked_message.reason)
+        end
+        connection.on_unblocked do
+          on_unblocked
         end
         connection
       end
@@ -71,5 +77,10 @@ module ActionSubscriber
       ::ActiveSupport::Notifications.instrument("connection_blocked.action_subscriber", :reason => reason)
     end
     private_class_method :on_blocked
+
+    def self.on_unblocked
+      ::ActiveSupport::Notifications.instrument("connection_unblocked.action_subscriber")
+    end
+    private_class_method :on_unblocked
   end
 end

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -30,9 +30,16 @@ module ActionSubscriber
           ::MarchHare::ThreadPools.fixed_of_size(options[:threadpool_size])
         end
         connection = ::MarchHare.connect(options)
+        connection.on_blocked do |reason|
+          on_blocked(reason)
+        end
+        connection
       else
         connection = ::Bunny.new(options)
         connection.start
+        connection.on_blocked do |blocked_message|
+          on_blocked(blocked_message.reason)
+        end
         connection
       end
     end
@@ -59,5 +66,10 @@ module ActionSubscriber
       }
     end
     private_class_method :connection_options
+
+    def self.on_blocked(reason)
+      ::ActiveSupport::Notifications.instrument("connection_blocked.action_subscriber", :reason => reason)
+    end
+    private_class_method :on_blocked
   end
 end

--- a/spec/lib/action_subscriber/rabbit_connection_spec.rb
+++ b/spec/lib/action_subscriber/rabbit_connection_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe ::ActionSubscriber::RabbitConnection do
+  let(:reason) { "low on disk" }
+
+  before { ActionSubscriber.draw_routes {} }
+
+  if ::RUBY_PLATFORM == "java"
+    it "can deliver an on_blocked message" do
+
+    end
+  else
+    it "can deliver an on_blocked message" do
+      expect(::ActiveSupport::Notifications).to receive(:instrument).
+        with("connection_blocked.action_subscriber", :reason => reason)
+
+      described_class.with_connection do |connection|
+        # NOTE: Trigger the receiving of a blocked message from the broker.
+        # It's a bit of a hack but it is a more realistic test without changing
+        # memory alarms.
+        connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Blocked.new(reason))
+      end
+    end
+  end
+end

--- a/spec/lib/action_subscriber/rabbit_connection_spec.rb
+++ b/spec/lib/action_subscriber/rabbit_connection_spec.rb
@@ -5,29 +5,59 @@ describe ::ActionSubscriber::RabbitConnection do
 
   before { ActionSubscriber.draw_routes {} }
 
-  if ::RUBY_PLATFORM == "java"
-    def trigger_mocked_blocking_event(connection, reason)
-      amqp_message = ::Java::ComRabbitmqClient::AMQP::Connection::Blocked::Builder.new.
-        reason(reason).build
-      amq_command = ::Java::ComRabbitmqClientImpl::AMQCommand.new(amqp_message)
+  context "on_block" do
+    if ::RUBY_PLATFORM == "java"
+      def trigger_mocked_blocking_event(connection, reason)
+        amqp_message = ::Java::ComRabbitmqClient::AMQP::Connection::Blocked::Builder.new.
+          reason(reason).build
+        amq_command = ::Java::ComRabbitmqClientImpl::AMQCommand.new(amqp_message)
 
-      connection.send(:processControlCommand, amq_command)
+        connection.send(:processControlCommand, amq_command)
+      end
+    else
+      def trigger_mocked_blocking_event(connection, reason)
+        connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Blocked.new(reason))
+      end
     end
-  else
-    def trigger_mocked_blocking_event(connection, reason)
-      connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Blocked.new(reason))
+
+    it "can deliver an on_blocked message" do
+      expect(::ActiveSupport::Notifications).to receive(:instrument).
+        with("connection_blocked.action_subscriber", :reason => reason)
+
+      described_class.with_connection do |connection|
+        # NOTE: Trigger the receiving of a blocked message from the broker.
+        # It's a bit of a hack but it is a more realistic test without changing
+        # memory alarms.
+        trigger_mocked_blocking_event(connection, reason)
+      end
     end
   end
 
-  it "can deliver an on_blocked message" do
-    expect(::ActiveSupport::Notifications).to receive(:instrument).
-      with("connection_blocked.action_subscriber", :reason => reason)
+  context "on_unblocked" do
+    if ::RUBY_PLATFORM == "java"
+      def trigger_mocked_unblocked_event(connection, reason)
+        amqp_message = ::Java::ComRabbitmqClient::AMQP::Connection::Unblocked::Builder.new.
+          build
+        amq_command = ::Java::ComRabbitmqClientImpl::AMQCommand.new(amqp_message)
 
-    described_class.with_connection do |connection|
-      # NOTE: Trigger the receiving of a blocked message from the broker.
-      # It's a bit of a hack but it is a more realistic test without changing
-      # memory alarms.
-      trigger_mocked_blocking_event(connection, reason)
+        connection.send(:processControlCommand, amq_command)
+      end
+    else
+      def trigger_mocked_unblocked_event(connection, reason)
+        connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Unblocked.new)
+      end
+    end
+
+    it "can deliver an on_unblocked message" do
+      expect(::ActiveSupport::Notifications).to receive(:instrument).
+        with("connection_unblocked.action_subscriber")
+
+      described_class.with_connection do |connection|
+        # NOTE: Trigger the receiving of an unblocked message from the broker.
+        # It's a bit of a hack but it is a more realistic test without changing
+        # memory alarms.
+        trigger_mocked_unblocked_event(connection, reason)
+      end
     end
   end
 end

--- a/spec/lib/action_subscriber/rabbit_connection_spec.rb
+++ b/spec/lib/action_subscriber/rabbit_connection_spec.rb
@@ -6,20 +6,28 @@ describe ::ActionSubscriber::RabbitConnection do
   before { ActionSubscriber.draw_routes {} }
 
   if ::RUBY_PLATFORM == "java"
-    it "can deliver an on_blocked message" do
+    def trigger_mocked_blocking_event(connection, reason)
+      amqp_message = ::Java::ComRabbitmqClient::AMQP::Connection::Blocked::Builder.new.
+        reason(reason).build
+      amq_command = ::Java::ComRabbitmqClientImpl::AMQCommand.new(amqp_message)
 
+      connection.send(:processControlCommand, amq_command)
     end
   else
-    it "can deliver an on_blocked message" do
-      expect(::ActiveSupport::Notifications).to receive(:instrument).
-        with("connection_blocked.action_subscriber", :reason => reason)
+    def trigger_mocked_blocking_event(connection, reason)
+      connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Blocked.new(reason))
+    end
+  end
 
-      described_class.with_connection do |connection|
-        # NOTE: Trigger the receiving of a blocked message from the broker.
-        # It's a bit of a hack but it is a more realistic test without changing
-        # memory alarms.
-        connection.send(:handle_frame, 0, ::AMQ::Protocol::Connection::Blocked.new(reason))
-      end
+  it "can deliver an on_blocked message" do
+    expect(::ActiveSupport::Notifications).to receive(:instrument).
+      with("connection_blocked.action_subscriber", :reason => reason)
+
+    described_class.with_connection do |connection|
+      # NOTE: Trigger the receiving of a blocked message from the broker.
+      # It's a bit of a hack but it is a more realistic test without changing
+      # memory alarms.
+      trigger_mocked_blocking_event(connection, reason)
     end
   end
 end


### PR DESCRIPTION
This adds a simple on_blocked/ on_unblocked handle on the rabbit connection which in turn fires an active support notification. This will be useful for debugging poor performance behavior. Current ideas:

1. Wire this to something like logstasher to get these events pumped into elastic search.
2. Add a harness subscription for something like `INC some.key.#{reason.gsub(/|W/, "_")}` which would turn the few reasons into keys by host. Could be interesting.

NOTE: I don't love the tests here but it seems better than faking the on_blocked callbacks higher up the stack since the apis differ. Feel free to disagree. Happy to change these.

cc @abrandoned @minond 