### PR TITLE
middlewareize resubscription process to allow application handling of errors

### DIFF
--- a/lib/action_subscriber/bunny/subscriber.rb
+++ b/lib/action_subscriber/bunny/subscriber.rb
@@ -30,8 +30,6 @@ module ActionSubscriber
         end
       end
 
-    private
-
       def start_subscriber_for_subscription(subscription)
         route = subscription[:route]
         queue = subscription[:queue]
@@ -43,11 +41,14 @@ module ActionSubscriber
         if ::ActionSubscriber.configuration.resubscribe_on_consumer_cancellation
           # Add cancellation callback to rebuild subscriber on cancel.
           consumer.on_cancellation do
-            ::ActionSubscriber.logger.warn "Cancelation received for queue consumer: #{queue.name}, rebuilding subscription..."
-            bunny_consumers.delete(consumer)
-            channel.close
-            queue = subscription[:queue] = setup_queue(route)
-            start_subscriber_for_subscription(subscription)
+            properties = {
+              :consumer => consumer,
+              :consumers => bunny_consumers,
+              :route_set => self,
+              :subscription => subscription
+            }
+            env = ::ActionSubscriber::Middleware::ResubscribeEnv.new(properties)
+            ::ActionSubscriber.config.resubscribe_middleware.call(env)
           end
         end
 

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -142,10 +142,6 @@ module ActionSubscriber
       [ host ]
     end
 
-    def middleware
-      @middleware ||= Middleware.initialize_stack
-    end
-
     def inspect
       inspection_string  = <<-INSPECT.strip_heredoc
         Rabbit Hosts: #{hosts}
@@ -156,6 +152,14 @@ module ActionSubscriber
       INSPECT
       decoder.each_key { |key| inspection_string << "  --#{key}\n" }
       return inspection_string
+    end
+
+    def middleware
+      @middleware ||= Middleware.initialize_stack
+    end
+
+    def resubscribe_middleware
+      @resubscribe_middleware ||= ::ActionSubscriber::Middleware.initialize_resubscribe_stack
     end
   end
 end

--- a/lib/action_subscriber/middleware.rb
+++ b/lib/action_subscriber/middleware.rb
@@ -2,6 +2,8 @@ require "action_subscriber/logging"
 require "action_subscriber/middleware/decoder"
 require "action_subscriber/middleware/env"
 require "action_subscriber/middleware/error_handler"
+require "action_subscriber/middleware/resubscribe_env"
+require "action_subscriber/middleware/resubscribe_handler"
 require "action_subscriber/middleware/router"
 require "action_subscriber/middleware/runner"
 
@@ -27,6 +29,13 @@ module ActionSubscriber
 
       builder.use ::ActionSubscriber::Middleware::ErrorHandler
       builder.use ::ActionSubscriber::Middleware::Decoder
+
+      builder
+    end
+
+    def self.initialize_resubscribe_stack
+      builder = ::ActionSubscriber::Middleware::Builder.new
+      builder.use ::ActionSubscriber::Middleware::ResubscribeHandler
 
       builder
     end

--- a/lib/action_subscriber/middleware/resubscribe_env.rb
+++ b/lib/action_subscriber/middleware/resubscribe_env.rb
@@ -1,0 +1,17 @@
+module ActionSubscriber
+  module Middleware
+    class ResubscribeEnv
+      attr_reader :consumer,
+                  :consumers,
+                  :route_set,
+                  :subscription
+
+      def initialize(properties)
+        @consumer = properties.fetch(:consumer)
+        @consumers = properties.fetch(:consumers)
+        @route_set = properties.fetch(:route_set)
+        @subscription = properties.fetch(:subscription)
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/middleware/resubscribe_handler.rb
+++ b/lib/action_subscriber/middleware/resubscribe_handler.rb
@@ -1,0 +1,26 @@
+module ActionSubscriber
+  module Middleware
+    class ResubscribeHandler
+      attr_reader :env
+      delegate :consumer, :consumers, :route_set, :subscription, :to => :env
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        @env = env
+        route = subscription[:route]
+        queue = subscription[:queue]
+
+        ::ActionSubscriber.logger.warn "Cancellation received for queue consumer: #{queue.name}, rebuilding subscription..."
+        consumers.delete(consumer)
+        queue.channel.close
+        subscription[:queue] = route_set.setup_queue(route)
+        route_set.start_subscriber_for_subscription(subscription)
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/action_subscriber/route_set.rb
+++ b/lib/action_subscriber/route_set.rb
@@ -14,6 +14,7 @@ module ActionSubscriber
 
     def print_middleware_stack
       ::ActionSubscriber.config.middleware.print_middleware_stack
+      ::ActionSubscriber.config.resubscribe_middleware.print_middleware_stack
     end
 
     def print_subscriptions

--- a/spec/lib/action_subscriber/middleware/resubscribe_env_spec.rb
+++ b/spec/lib/action_subscriber/middleware/resubscribe_env_spec.rb
@@ -1,0 +1,20 @@
+describe ActionSubscriber::Middleware::ResubscribeEnv do
+  let(:consumer) { instance_double("::Bunny::Consumer") }
+  let(:consumers) { [consumer] }
+  let(:properties){
+    {
+      :consumer => consumer,
+      :consumers => consumers,
+      :route_set => route_set,
+      :subscription => subscription,
+    }
+  }
+  let(:route_set) { instance_double("::ActionSubscriber::RouteSet") }
+  let(:subscription) { { :foo => "bar" } }
+  subject { described_class.new(properties) }
+
+  specify { expect(subject.consumer).to eq(consumer) }
+  specify { expect(subject.consumers).to eq(consumers) }
+  specify { expect(subject.route_set).to eq(route_set) }
+  specify { expect(subject.subscription).to eq(subscription) }
+end

--- a/spec/lib/action_subscriber/middleware/resubscribe_handler_spec.rb
+++ b/spec/lib/action_subscriber/middleware/resubscribe_handler_spec.rb
@@ -1,0 +1,40 @@
+describe ::ActionSubscriber::Middleware::ResubscribeHandler do
+  describe "#call" do
+    let(:app) { lambda { |_| true } }
+    let(:consumer1) { double("consumer1") }
+    let(:consumer2) { double("consumer2") }
+    let(:consumers) { [consumer1, consumer2] }
+    let(:env) {
+      ::ActionSubscriber::Middleware::ResubscribeEnv.new(
+        {
+          :consumer => consumer1,
+          :consumers => consumers,
+          :route_set => route_set,
+          :subscription => subscription
+        }
+      )
+    }
+    let(:new_queue) { double("new queue") }
+    let(:queue) { double("queue", :name => "some.queue") }
+    let(:route) { instance_double("::ActionSubscriber::Route") }
+    let(:route_set) { instance_double("::ActionSubscriber::RouteSet") }
+    let(:subscription) {
+      {
+        :queue => queue,
+        :route => route,
+      }
+    }
+    subject { described_class.new(app) }
+
+    it "removes consumer from list and sets up new queue" do
+      expect(queue).to receive_message_chain(:channel, :close)
+      expect(route_set).to receive(:setup_queue).with(route).and_return(new_queue)
+      expect(route_set).to receive(:start_subscriber_for_subscription).with(subscription)
+
+      subject.call(env)
+
+      expect(consumers).to eq [consumer2]
+      expect(subscription[:queue]).to eq(new_queue)
+    end
+  end
+end


### PR DESCRIPTION
Currently, should errors crop up in the automatic resubscription process, nothing handles them which can lead to dead subscribers with no notification of the problem.  By putting this into a middleware stack comparable to the "main" process, this will allow the implementing application to insert logic to potentially handle certain kinds of errors (e.g. to retry potentially transient ones) or at least add better logging capability when fatal errors do occur.