### PR TITLE
Touch a file on start and rm the same file on stop

### DIFF
--- a/lib/action_subscriber.rb
+++ b/lib/action_subscriber.rb
@@ -87,6 +87,18 @@ module ActionSubscriber
     route_set.wait_to_finish_with_timeout(timeout)
   end
 
+  def self.after_server_start(&block)
+    ::ActiveSupport::Notifications.subscribe("action_subscriber:server_started") do |*args|
+      block.call(*args)
+    end
+  end
+
+  def self.after_server_stop(&block)
+    ::ActiveSupport::Notifications.subscribe("action_subscriber:server_stopped") do |*args|
+      block.call(*args)
+    end
+  end
+
   # Execution is delayed until after app loads when used with bin/action_subscriber
   require "action_subscriber/railtie" if defined?(Rails)
   ::ActiveSupport.run_load_hooks(:action_subscriber, Base)

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -11,11 +11,11 @@ module ActionSubscriber
       ::ActionSubscriber.setup_subscriptions!
       ::ActionSubscriber.print_subscriptions
       ::ActionSubscriber.start_subscribers!
-      logger.info "Action Subscriber connected"
 
       ::FileUtils.mkdir_p(File.join(Rails.root, "tmp"))
       ::FileUtils.touch(File.join(Rails.root, "tmp", "subscriber-started"))
 
+      logger.info "Action Subscriber connected"
       while true
         sleep 1.0 #just hang around waiting for messages
         break if shutting_down?
@@ -26,6 +26,7 @@ module ActionSubscriber
       logger.info "Shutting down"
       ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
       logger.info "Shutdown complete"
+      ::FileUtils.remove_file(File.join(Rails.root, "tmp", "subscriber-started"), force = true)
       exit(0)
     end
 

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -1,4 +1,4 @@
-require "fileutils"
+require 'active_support/notifications'
 
 module ActionSubscriber
   module Babou
@@ -11,11 +11,8 @@ module ActionSubscriber
       ::ActionSubscriber.setup_subscriptions!
       ::ActionSubscriber.print_subscriptions
       ::ActionSubscriber.start_subscribers!
-
-      ::FileUtils.mkdir_p(File.join(Rails.root, "tmp"))
-      ::FileUtils.touch(File.join(Rails.root, "tmp", "subscriber-started"))
-
       logger.info "Action Subscriber connected"
+      ::ActiveSupport::Notifications.instrument("action_subscriber:server_started")
       while true
         sleep 1.0 #just hang around waiting for messages
         break if shutting_down?
@@ -26,7 +23,7 @@ module ActionSubscriber
       logger.info "Shutting down"
       ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
       logger.info "Shutdown complete"
-      ::FileUtils.remove_file(File.join(Rails.root, "tmp", "subscriber-started"), force = true)
+      ::ActiveSupport::Notifications.instrument("action_subscriber:server_stopped")
       exit(0)
     end
 

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -1,4 +1,4 @@
-require 'active_support/notifications'
+require "active_support/notifications"
 
 module ActionSubscriber
   module Babou

--- a/lib/action_subscriber/babou.rb
+++ b/lib/action_subscriber/babou.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 module ActionSubscriber
   module Babou
     ##
@@ -10,6 +12,9 @@ module ActionSubscriber
       ::ActionSubscriber.print_subscriptions
       ::ActionSubscriber.start_subscribers!
       logger.info "Action Subscriber connected"
+
+      ::FileUtils.mkdir_p(File.join(Rails.root, "tmp"))
+      ::FileUtils.touch(File.join(Rails.root, "tmp", "subscriber-started"))
 
       while true
         sleep 1.0 #just hang around waiting for messages

--- a/lib/action_subscriber/version.rb
+++ b/lib/action_subscriber/version.rb
@@ -1,3 +1,3 @@
 module ActionSubscriber
-  VERSION = "5.2.3"
+  VERSION = "5.2.4"
 end


### PR DESCRIPTION
Using the presence of subscriber-started file as an indicator for readiness. 