### PR TITLE
Fix YAML loading

### DIFF
--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'action_subscriber/version'
+require "action_subscriber/version"
 
 Gem::Specification.new do |spec|
   spec.name                  = "action_subscriber"
@@ -18,17 +18,18 @@ Gem::Specification.new do |spec|
   spec.test_files            = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths         = ["lib"]
 
-  spec.add_dependency 'activesupport', '>= 3.2'
+  spec.add_dependency "activesupport", ">= 3.2"
 
-  if ENV['PLATFORM'] == "java" || ::RUBY_PLATFORM == 'java'
+  if ENV["PLATFORM"] == "java" || ::RUBY_PLATFORM == "java"
     spec.platform = "java"
-    spec.add_dependency 'march_hare', '~> 4.4'
+    spec.add_dependency "march_hare", "~> 4.4"
   else
-    spec.add_dependency 'bunny', '>= 1.5.0'
+    spec.add_dependency "bunny", ">= 1.5.0"
   end
-  spec.add_dependency 'concurrent-ruby'
-  spec.add_dependency 'middleware'
-  spec.add_dependency 'thor'
+  spec.add_dependency "concurrent-ruby"
+  spec.add_dependency "middleware"
+  spec.add_dependency "psych", ">= 3.3.2"
+  spec.add_dependency "thor"
 
   spec.add_development_dependency "active_publisher", "~> 0.1.5"
   spec.add_development_dependency "activerecord", ">= 3.2"

--- a/lib/action_subscriber/configuration.rb
+++ b/lib/action_subscriber/configuration.rb
@@ -69,11 +69,9 @@ module ActionSubscriber
           absolute_config_path = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
           if ::File.exists?(absolute_config_path)
             erb = ::ERB.new(::File.read(absolute_config_path)).result
-            if defined?(SafeYAML)
-              yaml_config = ::YAML.load(erb, :safe => true)[env]
-            else
-              yaml_config = ::YAML.load(erb)[env]
-            end
+            # Defined in Psych 3.2+ and the new canonical way to load trusted documents:
+            # https://github.com/ruby/psych/issues/533#issuecomment-1019363688
+            yaml_config = ::YAML.unsafe_load(erb)[env]
           end
 
           ::ActionSubscriber::Configuration::DEFAULTS.each_pair do |key, value|


### PR DESCRIPTION
Psych (aka YAML) 4.x included a breaking change to how `YAML.load` works In Psych 4.0, `load` calls `safe_load` under the hood, and is therefore "safe" by default, but that breaks configurations that support (among other things) aliases, which are disabled when using "safe" loading.

`unsafe_load` is now the canonical way to load trusted documents (i.e., config files): https://github.com/ruby/psych/issues/533#issuecomment-1019363688

To ensure maximum compatibility with old versions of Psych, we also need to set a minimum version of Psych to ensure `unsafe_load` is defined. The methods were introduced in v3.3.2: https://github.com/ruby/psych/commit/cb50aa8d3fb8be01897becff77b4922b12a0ab4c

Resolves #116

// @elbowdonkey @ETetzlaff @skunkworker 