### PR TITLE
Rails 6.1 local application name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,3 +60,4 @@ workflows:
                 - cimg/ruby:3.1
                 - circleci/jruby:9.2
                 - circleci/jruby:9.3
+                - circleci/jruby:9.4

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -58,7 +58,11 @@ module ActionSubscriber
                                  when ENV['APP_NAME'] then
                                    ENV['APP_NAME'].to_s.dup
                                  when defined?(::Rails) then
-                                   ::Rails.application.class.parent_name.dup
+                                   if ::Rails.application.class.respond_to?("module_parent_name")
+                                     ::Rails.application.class.module_parent_name.dup
+                                   else
+                                     ::Rails.application.class.parent_name.dup
+                                   end
                                  else
                                    raise "Define an application name (ENV['APP_NAME'])"
                                  end

--- a/lib/action_subscriber/router.rb
+++ b/lib/action_subscriber/router.rb
@@ -58,7 +58,7 @@ module ActionSubscriber
                                  when ENV['APP_NAME'] then
                                    ENV['APP_NAME'].to_s.dup
                                  when defined?(::Rails) then
-                                   if ::Rails.application.class.respond_to?("module_parent_name")
+                                   if ::Rails.application.class.respond_to?(:module_parent_name)
                                      ::Rails.application.class.module_parent_name.dup
                                    else
                                      ::Rails.application.class.parent_name.dup

--- a/lib/action_subscriber/subscribable.rb
+++ b/lib/action_subscriber/subscribable.rb
@@ -35,7 +35,11 @@ module ActionSubscriber
                               when ENV['APP_NAME'] then
                                 ENV['APP_NAME'].to_s.dup
                               when defined?(::Rails) then
-                                ::Rails.application.class.parent_name.dup
+                                if ::Rails.application.class.respond_to?("module_parent_name")
+                                  ::Rails.application.class.module_parent_name.dup
+                                else
+                                  ::Rails.application.class.parent_name.dup
+                                end
                               else
                                 raise "Define an application name (ENV['APP_NAME'])"
                               end

--- a/lib/action_subscriber/subscribable.rb
+++ b/lib/action_subscriber/subscribable.rb
@@ -35,7 +35,7 @@ module ActionSubscriber
                               when ENV['APP_NAME'] then
                                 ENV['APP_NAME'].to_s.dup
                               when defined?(::Rails) then
-                                if ::Rails.application.class.respond_to?("module_parent_name")
+                                if ::Rails.application.class.respond_to?(:module_parent_name)
                                   ::Rails.application.class.module_parent_name.dup
                                 else
                                   ::Rails.application.class.parent_name.dup


### PR DESCRIPTION
The `parent_name` method has been replaced with `module_parent_name` in Rails 6.1. Let's add a check for the new method and also make it backwards compatible.

* https://apidock.com/rails/v6.0.0/Module/parent_name
* https://apidock.com/rails/v6.0.0/Module/module_parent_name
